### PR TITLE
Update rails-postgres example to use PostgreSQL

### DIFF
--- a/ruby/rails-postgres/app/Gemfile
+++ b/ruby/rails-postgres/app/Gemfile
@@ -5,8 +5,7 @@ ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Use SCSS for stylesheets

--- a/ruby/rails-postgres/app/Gemfile.lock
+++ b/ruby/rails-postgres/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /integration
   specs:
-    appsignal (2.11.1)
+    appsignal (2.11.2)
       rack
 
 GEM
@@ -91,6 +91,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pg (1.2.3)
     puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -143,7 +144,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -164,10 +164,10 @@ DEPENDENCIES
   appsignal!
   jbuilder (~> 2.7)
   listen
+  pg
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   sass-rails (>= 6)
-  sqlite3 (~> 1.4)
   turbolinks (~> 5)
 
 RUBY VERSION

--- a/ruby/rails-postgres/app/config/database.yml
+++ b/ruby/rails-postgres/app/config/database.yml
@@ -1,25 +1,19 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  adapter: postgresql
+  encoding: unicode
+  host: postgres
+  pool: 5
+  username: app
+  password: password
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: app_db
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: app_db
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: sample_postgres_production

--- a/ruby/rails-postgres/app/db/schema.rb
+++ b/ruby/rails-postgres/app/db/schema.rb
@@ -12,6 +12,9 @@
 
 ActiveRecord::Schema.define(version: 2020_11_08_223710) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "items", force: :cascade do |t|
     t.string "name"
     t.text "description"

--- a/ruby/rails-postgres/commands/boot.sh
+++ b/ruby/rails-postgres/commands/boot.sh
@@ -1,14 +1,21 @@
 #!/bin/sh
 
-echo "Install dependencies"
-cd /app && bundle install --path=vendor/bundle
-cd /app && npm install --prefix=vendor/npm
+set -eu
 
 echo "Install appsignal"
 cd /integration && rake extension:install
 
+cd /app
+
+echo "Install dependencies"
+bundle install --path=vendor/bundle
+npm install --prefix=vendor/npm
+
 echo "Clean tmp"
-rm -rf /app/tmp
+rm -rf tmp
+
+echo "Running migrations"
+bin/rails db:migrate
 
 echo "Running rails server"
-cd /app && bin/rails server -b 0.0.0.0
+bin/rails server -b 0.0.0.0


### PR DESCRIPTION

The rails postgres app didn't actually use the postgres database that
was spun up alongside it. It was using sqlite.

The app now uses the PostgreSQL database and runs the migrations
automatically on boot so the user doesn't have to run the manually after
start.