### PR TITLE
Make default app port 4001

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ To start a test setup:
 ```
 rake app=elixir/alpine-release app:up
 rake app=elixir/phoenix-example app:up
+rake app=ruby/shoryuken app:up
+rake app=ruby/single-task app:up
 rake app=ruby/rails-postgres app:up
 rake app=nodejs/express-postgres app:up
 ```
 
 This will boot a test environment with AppSignal enabled listening on
-[localhost](http://localhost:3000). The agent log and lock files are
+[localhost](http://localhost:4001). The agent log and lock files are
 accessible in the `working_directory`.
 
 To restart the app container after making changes to an integration:
@@ -38,6 +40,8 @@ To restart the app container after making changes to an integration:
 ```
 rake app=elixir/alpine-release app:restart
 rake app=elixir/phoenix-example app:restart
+rake app=ruby/shoryuken app:restart
+rake app=ruby/single-task app:restart
 rake app=ruby/rails-postgres app:restart
 rake app=nodejs/express-postgres app:restart
 ```
@@ -47,6 +51,8 @@ To run bash:
 ```
 rake app=elixir/alpine-release app:bash
 rake app=elixir/phoenix-example app:bash
+rake app=ruby/shoryuken app:bash
+rake app=ruby/single-task app:bash
 rake app=ruby/rails-postgres app:bash
 rake app=nodejs/express-postgres app:bash
 ```
@@ -56,6 +62,8 @@ To run the console (if implemented in the test app):
 ```
 rake app=elixir/alpine-release app:console
 rake app=elixir/phoenix-example app:console
+rake app=ruby/shoryuken app:console
+rake app=ruby/single-task app:console
 rake app=ruby/rails-postgres app:console
 rake app=nodejs/express-postgres app:console
 ```
@@ -65,7 +73,10 @@ To send in a diagnose (if implemented in the test app);
 ```
 rake app=elixir/alpine-release app:diagnose
 rake app=elixir/phoenix-example app:diagnose
+rake app=ruby/shoryuken app:diagnose
+rake app=ruby/single-task app:diagnose
 rake app=ruby/rails-postgres app:diagnose
+rake app=nodejs/express-postgres app:diagnose
 ```
 
 Tail the appsignal log:
@@ -73,6 +84,8 @@ Tail the appsignal log:
 ```
 rake app=elixir/alpine-release app:tail:appsignal
 rake app=elixir/phoenix-example app:tail:appsignal
+rake app=ruby/shoryuken app:tail:appsignal
+rake app=ruby/single-task app:tail:appsignal
 rake app=ruby/rails-postgres app:tail:appsignal
 rake app=nodejs/express-postgres app:tail:appsignal
 ```
@@ -99,5 +112,5 @@ rake app=lang/app app:new
 
 Then customize the generated files and place your code in `app` within
 the generated skeleton app. Make sure to map the port to localhost to
-`3000`. If you want to run tasks such as generators do that from within
+`4001`. If you want to run tasks such as generators do that from within
 the Docker setup by using the `app:bash` task.

--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ end
 namespace :app do
   desc "Open the browser pointing to the app"
   task :open do
-    run_command "open http://localhost:3000"
+    run_command "open http://localhost:4001"
   end
 
   desc "Create a test setup skeleton"

--- a/elixir/alpine-release/docker-compose.yml
+++ b/elixir/alpine-release/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3.8'
 services:
   postgres:
     image: postgres
-    ports:
-      - "5432:5432"
     env_file:
       - postgres.env
   app:
@@ -12,7 +10,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - "3000:4000"
+      - "4001:4000"
     environment:
       - APPSIGNAL_APP_NAME=elixir-alpine-release
     env_file:

--- a/elixir/phoenix-example/docker-compose.yml
+++ b/elixir/phoenix-example/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3.8'
 services:
   postgres:
     image: postgres
-    ports:
-      - "5432:5432"
     env_file:
       - postgres.env
   app:
@@ -12,7 +10,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - "3000:4000"
+      - "4001:4000"
     environment:
       - APPSIGNAL_APP_NAME=elixir-phoenix-example
     env_file:

--- a/nodejs/express-postgres/docker-compose.yml
+++ b/nodejs/express-postgres/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3.8'
 services:
   postgres:
     image: postgres
-    ports:
-      - "5432:5432"
     env_file:
       - postgres.env
   app:
@@ -12,7 +10,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - "3000:3000"
+      - "4001:3000"
     environment:
       - APPSIGNAL_APP_NAME=nodejs-express-postgres
     env_file:

--- a/ruby/rails-postgres/commands/boot.sh
+++ b/ruby/rails-postgres/commands/boot.sh
@@ -18,4 +18,4 @@ echo "Running migrations"
 bin/rails db:migrate
 
 echo "Running rails server"
-bin/rails server -b 0.0.0.0
+bin/rails server --binding=0.0.0.0

--- a/ruby/rails-postgres/docker-compose.yml
+++ b/ruby/rails-postgres/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3.8'
 services:
   postgres:
     image: postgres
-    ports:
-      - "5432:5432"
     env_file:
       - postgres.env
   app:
@@ -12,7 +10,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - "3000:3000"
+      - "4001:3000"
     environment:
       - APPSIGNAL_APP_NAME=ruby-rails-postgres
     env_file:

--- a/ruby/shoryuken/app/Gemfile.lock
+++ b/ruby/shoryuken/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /integration
   specs:
-    appsignal (2.11.2)
+    appsignal (2.11.3)
       rack
 
 GEM

--- a/ruby/shoryuken/docker-compose.yml
+++ b/ruby/shoryuken/docker-compose.yml
@@ -3,14 +3,10 @@ version: '3.8'
 services:
   motoserver:
     image: motoserver/moto
-    ports:
-      - "5000:5000"
   app:
     image: ruby/shoryuken:latest
     depends_on:
       - motoserver
-    ports:
-      - "3000:3000"
     environment:
       - APPSIGNAL_APP_NAME=ruby-shoryuken
     env_file:

--- a/ruby/single-task/docker-compose.yml
+++ b/ruby/single-task/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3.8'
 services:
   app:
     image: ruby/single-task:latest
-    ports:
-      - "3000:3000"
     environment:
       - APPSIGNAL_APP_NAME=ruby-single-task
     env_file:

--- a/support/templates/README.md.erb
+++ b/support/templates/README.md.erb
@@ -27,7 +27,7 @@ To start a test setup:
 <% end %>```
 
 This will boot a test environment with AppSignal enabled listening on
-[localhost](http://localhost:3000). The agent log and lock files are
+[localhost](http://localhost:4001). The agent log and lock files are
 accessible in the `working_directory`.
 
 To restart the app container after making changes to an integration:
@@ -82,5 +82,5 @@ rake app=lang/app app:new
 
 Then customize the generated files and place your code in `app` within
 the generated skeleton app. Make sure to map the port to localhost to
-`3000`. If you want to run tasks such as generators do that from within
+`4001`. If you want to run tasks such as generators do that from within
 the Docker setup by using the `app:bash` task.

--- a/support/templates/skeleton/docker-compose.yml.erb
+++ b/support/templates/skeleton/docker-compose.yml.erb
@@ -4,7 +4,7 @@ services:
   app:
     image: <%= @app %>:latest
     ports:
-      - "3000:3000"
+      - "4001:3000"
     environment:
       - APPSIGNAL_APP_NAME=<%= @app.gsub('/', '-') %>
     env_file:


### PR DESCRIPTION
Port 4001 should not conflict with most apps that can also run on the
host machine at the same time.

I also removed all the other `ports:` statements for databases from the
`docker-compose.yml` files. The `ports:` statements expose ports from
the container to the host server, and for databases this is not required
to function. All containers are on their own network and can communicate
with each other without explicitly exposing ports between containers.

Closes #10