### PR TITLE
Use docker compose to build images

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -117,8 +117,8 @@ namespace :app do
     @app = get_app
     puts "Starting #{@app}"
 
-    puts "Building..."
-    run_command "cd #{@app} && docker build -t #{@app} ."
+    puts "Building environment..."
+    run_command "cd #{@app} && docker-compose build"
 
     puts "Starting compose..."
     run_command "cd #{@app} && docker-compose up"

--- a/elixir/alpine-release/docker-compose.yml
+++ b/elixir/alpine-release/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     env_file:
       - postgres.env
   app:
-    image: elixir/alpine-release:latest
+    build: .
+    image: elixir/alpine-release
     depends_on:
       - postgres
     ports:

--- a/elixir/phoenix-example/docker-compose.yml
+++ b/elixir/phoenix-example/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     env_file:
       - postgres.env
   app:
-    image: elixir/phoenix-example:latest
+    build: .
+    image: elixir/phoenix-example
     depends_on:
       - postgres
     ports:

--- a/nodejs/express-postgres/docker-compose.yml
+++ b/nodejs/express-postgres/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     env_file:
       - postgres.env
   app:
-    image: nodejs/express-postgres:latest
+    build: .
+    image: nodejs/express-postgres
     depends_on:
       - postgres
     ports:

--- a/ruby/rails-postgres/docker-compose.yml
+++ b/ruby/rails-postgres/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     env_file:
       - postgres.env
   app:
-    image: ruby/rails-postgres:latest
+    build: .
+    image: ruby/rails-postgres
     depends_on:
       - postgres
     ports:

--- a/ruby/shoryuken/docker-compose.yml
+++ b/ruby/shoryuken/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   motoserver:
     image: motoserver/moto
   app:
-    image: ruby/shoryuken:latest
+    build: .
+    image: ruby/shoryuken
     depends_on:
       - motoserver
     environment:

--- a/ruby/single-task/docker-compose.yml
+++ b/ruby/single-task/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.8'
 
 services:
   app:
-    image: ruby/single-task:latest
+    build: .
+    image: ruby/single-task
     environment:
       - APPSIGNAL_APP_NAME=ruby-single-task
     env_file:

--- a/support/templates/skeleton/docker-compose.yml.erb
+++ b/support/templates/skeleton/docker-compose.yml.erb
@@ -2,7 +2,8 @@ version: '3.8'
 
 services:
   app:
-    image: <%= @app %>:latest
+    build: .
+    image: <%= @app %>
     ports:
       - "4001:3000"
     environment:


### PR DESCRIPTION
Instead using using `docker build` and tagging an image manually, use
`docker-compose build` and let it tag the image based on the image name
defined in the `docker-compose.yml` file.

When I was adding a react app using the JavaScript integration I moved
it from the `nodejs` to the `javascript` directory, and didn't realize
the docker image was automatically tagged based on the directory name
and the image name referred to in the `docker-compose.yml` file didn't
match anymore. I was building a new image but still testing against the
old image.

This change moves all that config to the `docker-compose.yml` file and
doesn't base the image name on the app directory anymore, only during
`rake app:new` when the `docker-compose.yml` is generated. By specifying
`build: .` in the `docker-compose.yml` file we specify the context for
where the `Dockerfile` can be found.

I also removed the tag from the build process and image name. If none is
specified docker compose automatically uses the "latest" tag.