### PR TITLE
Use NFS volumes to speed up builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -109,7 +109,7 @@ namespace :app do
   end
 
   desc "Start a test app"
-  task :up do
+  task :up => :prepare_nfs do
     unless File.exist?("appsignal_key.env")
       raise "No push api key set yet, run rake global:set_push_api_key key=<key>"
     end
@@ -174,6 +174,81 @@ namespace :app do
       @app = get_app
       run_command "cd #{@app} && docker-compose exec app tail -f /tmp/appsignal.log"
     end
+  end
+
+  task :prepare_nfs do
+    require "rbconfig"
+    unless RbConfig::CONFIG["host_os"].downcase.start_with? "darwin"
+      puts "Warning: Skipping NFS check. Host system is not macOS. Use at own risk."
+    end
+
+    exports_path = "/etc/exports"
+    exports = File.read(exports_path)
+    required_exports = %(/Users -alldirs -mapall=#{Process.uid}:#{Process.gid} localhost)
+    exports_missing = false
+    exports_missing = true unless exports.include?(required_exports)
+
+    nfs_config_path = "/etc/nfs.conf"
+    nfs_config = File.read(nfs_config_path)
+    required_nfs_config = "nfs.server.mount.require_resv_port = 0"
+    nfs_config_missing = false
+    nfs_config_missing = true unless nfs_config.include?(required_nfs_config)
+
+    if exports_missing || nfs_config_missing
+      puts "Warning: Some system config is missing for NFS volumes support."
+      puts "We will need to shut down all Docker setups (docker-compose down) and restart Docker."
+      puts "Please make sure you have stopped any running containers before continuing."
+      puts "Press `y` to continue. Press any other key to exit."
+      print "Continue? "
+      input = $stdin.gets.chomp
+      if input == "y"
+        puts "Configuring NFS volumes on the system."
+        puts "Stopping all apps."
+        Dir["{#{LANGUAGES.join(",")}}/*"].each do |dir|
+          next if dir.end_with?("integration")
+
+          puts "Running: `docker-compose down` for `#{dir}`"
+          `cd #{dir} && docker-compose down`
+        end
+
+        puts "Stopping Docker."
+        `osascript -e 'quit app "Docker"'`
+      else
+        puts "Exiting without configuring NFS volumes."
+        exit 1
+      end
+    else
+      next # Config correct, skipping
+    end
+
+    if exports_missing
+      puts
+      puts "Warning: Exports not set up"
+      puts "Setting exports for NFS volumes."
+      puts "This may prompt for your password and prompt a macOS security confirmation."
+      puts
+      `echo #{required_exports} | sudo tee -a #{exports_path}`
+    end
+
+    if nfs_config_missing
+      puts
+      puts "Warning: NFS not set up"
+      puts "Configuring NFS volumes."
+      puts "This may prompt for your password and prompt a macOS security confirmation."
+      puts
+      `echo #{required_nfs_config} | sudo tee -a #{nfs_config_path}`
+    end
+
+    puts
+    puts "Restarting NFS. This may prompt for your password."
+    `sudo nfsd restart`
+
+    puts
+    puts "Starting Docker."
+    `open -a Docker`
+
+    puts
+    puts "Configuration done. Now continuing."
   end
 end
 

--- a/elixir/alpine-release/docker-compose.yml
+++ b/elixir/alpine-release/docker-compose.yml
@@ -19,5 +19,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/elixir/phoenix-example/docker-compose.yml
+++ b/elixir/phoenix-example/docker-compose.yml
@@ -19,5 +19,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/javascript/react/docker-compose.yml
+++ b/javascript/react/docker-compose.yml
@@ -12,5 +12,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/javascript/webpack/docker-compose.yml
+++ b/javascript/webpack/docker-compose.yml
@@ -14,5 +14,19 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"

--- a/nodejs/express-postgres/docker-compose.yml
+++ b/nodejs/express-postgres/docker-compose.yml
@@ -19,5 +19,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/nodejs/next-js/docker-compose.yml
+++ b/nodejs/next-js/docker-compose.yml
@@ -12,5 +12,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/ruby/rails-postgres/docker-compose.yml
+++ b/ruby/rails-postgres/docker-compose.yml
@@ -19,5 +19,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/ruby/rails-sidekiq/docker-compose.yml
+++ b/ruby/rails-sidekiq/docker-compose.yml
@@ -24,5 +24,19 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"

--- a/ruby/shoryuken/docker-compose.yml
+++ b/ruby/shoryuken/docker-compose.yml
@@ -15,5 +15,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/ruby/single-task/docker-compose.yml
+++ b/ruby/single-task/docker-compose.yml
@@ -10,5 +10,20 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"
+    volumes:

--- a/support/templates/skeleton/docker-compose.yml.erb
+++ b/support/templates/skeleton/docker-compose.yml.erb
@@ -12,5 +12,19 @@ services:
       - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
-      - ./app:/app
-      - ../integration:/integration
+      - "nfsmount_app:/app"
+      - "nfsmount_integration:/integration"
+
+volumes:
+  nfsmount_app:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/app"
+  nfsmount_integration:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/../integration"


### PR DESCRIPTION
Docker volume performance on macOS is not great. Apps that rely on a lot
of file system interaction (reading and writing) are much slower on the
mounted volume than the host system.

Use NFS volumes to speed up the mounted volumes. NFS seems much faster
for apps such as Node.js, as per a very basic speed test comparison:

Docker volume vs NFS volume speed test running `yarn install` in
`appsignal-javascript/packages/javascript`, lower is better:

- standard volume: 307.25s
- NFS volume: 122.22s

No significant increase of build time for `yarn build` for the same
package, lower is better:

- standard volume: 33.59s
- NFS volume: 28.97s

Closes #17 

## Installation

On macOS there are some additional steps required to set up NFS volumes
on the system. I've added this in an automated way to the
`app:prepare_nfs` task, which runs before `app:up`. This way a user
shouldn't have to bother with these steps manually or run a separate
task beforehand.

It is based on this gist:
https://gist.github.com/seanhandley/7dad300420e5f8f02e7243b7651c6657
From this article:
https://sean-handley.medium.com/how-to-set-up-docker-for-mac-with-native-nfs-145151458adc