### PR TITLE
Clean agent extension for NodeJS test apps

### DIFF
--- a/nodejs/express-apollo/commands/prepare
+++ b/nodejs/express-apollo/commands/prepare
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  rm -f /integration/packages/nodejs-ext/ext/appsignal-agent
   script/setup
   source ~/.bashrc
   mono bootstrap

--- a/nodejs/express-postgres/commands/prepare
+++ b/nodejs/express-postgres/commands/prepare
@@ -15,6 +15,7 @@ psql $host \
 echo "Install, link and build integration"
 (
   cd /integration
+  rm -f /integration/packages/nodejs-ext/ext/appsignal-agent
   script/setup
   mono bootstrap
   mono build

--- a/nodejs/koa/commands/prepare
+++ b/nodejs/koa/commands/prepare
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  rm -f /integration/packages/nodejs-ext/ext/appsignal-agent
   script/setup
   mono bootstrap
   mono build

--- a/nodejs/next-js/commands/prepare
+++ b/nodejs/next-js/commands/prepare
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  rm -f /integration/packages/nodejs-ext/ext/appsignal-agent
   script/setup
   mono bootstrap
   mono build


### PR DESCRIPTION
When the agent extension has been already built from the host machine,
it gets moved to the integrations volume on Docker container. This makes
the agent crash on application startup due to architecture differences.

Removing it before doing the build forces the process to recreate the
binary using the correct architecture.