### PR TITLE
Make Koa setup compatible with error helpers

### DIFF
--- a/nodejs/koa/app/app.js
+++ b/nodejs/koa/app/app.js
@@ -11,9 +11,7 @@ console.log("Starting KOA app");
 app.on("error", (error) => {
   appsignal
     .tracer()
-    .currentSpan()
-    .addError(error)
-    .close()
+    .setError(error)
 });
 
 // logger


### PR DESCRIPTION
Due to the addition of new error tracking helpers in NodeJS library,
NextJS test setup needed and update to stop using `span.addError()` and
start using `tracer.setError()`

Please, merge after the release of https://github.com/appsignal/appsignal-nodejs/pull/446