### PR TITLE
Fix Next.js test setup

### DIFF
--- a/nodejs/next-js/app/package.json
+++ b/nodejs/next-js/app/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@appsignal/nextjs": "*",
     "@appsignal/nodejs": "*",
-    "next": "~> 10.0",
+    "next": "^ 10.0",
     "react": "~> 17.0",
     "react-dom": "~> 17.0"
   }


### PR DESCRIPTION
The Next.js test setup specified `~> 10.0` for its dependency on the `next` package, which limits it to versions of the form `10.0.x`. However, our Next.js integration package currently requires `>= 10.2.3`.

This commit changes the test setup's specified dependency to `^ 10.0`, so that it accepts any versions of the form `10.x.x`.