### PR TITLE
Use Elixir remote shell for `app:console`

### DIFF
--- a/elixir/alpine-release/commands/console
+++ b/elixir/alpine-release/commands/console
@@ -2,5 +2,4 @@
 
 set -eu
 
-cd /app
-iex -S mix
+/tmp/release/bin/demo remote

--- a/elixir/phoenix-example/app/processmon.toml
+++ b/elixir/phoenix-example/app/processmon.toml
@@ -11,6 +11,6 @@ path = "/integration"
 ignore = ["appsignal-elixir/priv"]
 
 [processes.app]
-command = "mix"
-args = ["phx.server"]
+command = "elixir"
+args = ["--sname", "server", "--cookie", "server", "-S", "mix", "phx.server"]
 working_dir = "/app"

--- a/elixir/phoenix-example/commands/console
+++ b/elixir/phoenix-example/commands/console
@@ -2,5 +2,4 @@
 
 set -eu
 
-cd /app
-iex -S mix
+iex --sname console --cookie server --remsh server


### PR DESCRIPTION
The current implementation of the `app:console` command for the Phoenix application attempts to call `iex -S mix phx.server`. This command would start a new server and provide you with a shell to it, but since `app:console` is a `docker exec` command, it must be executed after `app:up` (`docker run`), which itself starts a server. Since a server is already running, the port is already in use and the console-spawned server fails to start. Even if this worked, spawning a new server with a console attached to it is not the same as attaching a console to the already running server.

For the `phoenix-example` test setup, this commit changes it so that the server spawned on `app:up` has an Erlang node name. This makes it possible for `app:console` to attach an `iex` remote shell to that node.

For the `alpine-release` test setup, since the test setup is ran from the binary provided by `mix release`, we use the `remote` command provided by the release binary to the same effect.