### PR TITLE
Update react app

### DIFF
--- a/javascript/react/app/package.json
+++ b/javascript/react/app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@appsignal/javascript": "^1.3.11",
+    "@appsignal/react": "^1.0.15",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.0",

--- a/javascript/react/app/src/App.js
+++ b/javascript/react/app/src/App.js
@@ -1,8 +1,24 @@
 import logo from './logo.svg';
 import './App.css';
-import Appsignal from "./Appsignal";
+import appsignal from "./Appsignal";
+import { ErrorBoundary } from "@appsignal/react";
 
-Appsignal.demo();
+
+const FallbackComponent = () => (
+  <div>Uh oh! There was an error :(</div>
+);
+
+function AppWrapper() {
+  return (
+    <ErrorBoundary
+      instance={appsignal}
+      tags={{ tag: "value" }}
+      fallback={(error) => <FallbackComponent />}
+    >
+      <App />
+    </ErrorBoundary>
+  );
+}
 
 function App() {
   return (
@@ -28,4 +44,4 @@ function App() {
   );
 }
 
-export default App;
+export default AppWrapper;

--- a/javascript/react/commands/run
+++ b/javascript/react/commands/run
@@ -6,6 +6,7 @@ set -eu
   cd /integration
   script/setup
   mono bootstrap
+  mono clean
   mono build
 )
 
@@ -13,7 +14,7 @@ cd /app
 
 echo "Install dependencies"
 yarn install
-yarn link @appsignal/types @appsignal/javascript
+yarn link @appsignal/types @appsignal/core @appsignal/javascript @appsignal/react
 
 echo "Starting app"
 yarn start


### PR DESCRIPTION
## Link react package in react test app

This makes testing against the local package possible.

## Add React ErrorBoundary to test app

This way we can actually track the errors in the way the
`@appsignal/react` package provides. Remove the demo call, because we
should test the render errors instead.

[skip review]