### PR TITLE
Track errors in React using ErrorBoundary

### DIFF
--- a/javascript/react/app/src/App.js
+++ b/javascript/react/app/src/App.js
@@ -2,7 +2,7 @@ import logo from './logo.svg';
 import './App.css';
 import appsignal from "./Appsignal";
 import { ErrorBoundary } from "@appsignal/react";
-
+import { useState } from "react";
 
 const FallbackComponent = () => (
   <div>Uh oh! There was an error :(</div>
@@ -21,6 +21,17 @@ function AppWrapper() {
 }
 
 function App() {
+  const [withError, setWithError] = useState(false);
+  const triggerError = () => {
+    setWithError(true);
+  }
+  if (withError) {
+    // Throw error in render function, rather than the `triggerError` event
+    // handler. Errors in event handlers are not picked up by the
+    // ErrorBoundary.
+    throw new Error("I crashed the page")
+  }
+
   return (
     <div className="App">
       <header className="App-header">
@@ -28,6 +39,7 @@ function App() {
         <p>
           Welcome to the React test app!
         </p>
+        <p><button onClick={triggerError}>Trigger error</button></p>
         <p>
           Edit <code>src/App.js</code> and save to reload.
         </p>


### PR DESCRIPTION
Throw an error in the React test app when a user click the "Trigger
error" button.

This needs to be done in the render function, rather than the
`triggerError` event handler. Errors in event handlers are not picked up
by the ErrorBoundary. This is how it works in React:
https://reactjs.org/docs/error-boundaries.html#how-about-event-handlers

[skip review]