### PR TITLE
Downgrade rails-sidekiq to Node 14.x

### DIFF
--- a/ruby/rails-sidekiq/Dockerfile
+++ b/ruby/rails-sidekiq/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:3.0.2
 ENV REFRESHED_AT=2021-02-10
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_15.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
   apt-get install -y nodejs python2 && \
   npm install -g npm && \
   npm install -g yarn


### PR DESCRIPTION
Something seems to have changed in one of the dependencies (`@npmcli/fs`) and they've dropped Node 15 support. I'm guessing it relates to [Node 15 no longer being supported, as it's an odd release](https://nodejs.org/en/about/releases/). I've downgraded the project to Node 14, which fixes the issue with the dependencies and allows the app to run and the tests to pass.

A more in-depth re-building of this and other sample projects, as @tombruijn mentioned in a comment in #42, would be nice, but for now this fixes the issue with the tests, and thus fixes #42.