### PR TITLE
Build only needed Javascript packages

### DIFF
--- a/javascript/ember/commands/run
+++ b/javascript/ember/commands/run
@@ -7,7 +7,7 @@ set -eu
   script/setup
   mono bootstrap
   mono clean
-  mono build
+  mono build --package=@appsignal/types,@appsignal/core,@appsignal/javascript,@appsignal/ember
 )
 
 cd /app

--- a/javascript/react/commands/run
+++ b/javascript/react/commands/run
@@ -7,7 +7,7 @@ set -eu
   script/setup
   mono bootstrap
   mono clean
-  mono build
+  mono build --package=@appsignal/types,@appsignal/core,@appsignal/javascript,@appsignal/react
 )
 
 cd /app

--- a/javascript/typescript-angular/commands/run
+++ b/javascript/typescript-angular/commands/run
@@ -6,14 +6,14 @@ set -eu
   cd /integration
   script/setup
   mono bootstrap
-  mono build
+  mono build --package=@appsignal/types,@appsignal/core,@appsignal/javascript,@appsignal/angular,@appsignal/webpack
 )
 
 cd /app
 
 echo "Install dependencies"
 yarn install
-yarn link @appsignal/types @appsignal/javascript @appsignal/angular @appsignal/webpack
+yarn link @appsignal/types @appsignal/core @appsignal/javascript @appsignal/angular @appsignal/webpack
 
 echo "Host running"
 echo "To test the app, run the following command:"

--- a/javascript/vanilla/commands/run
+++ b/javascript/vanilla/commands/run
@@ -6,14 +6,14 @@ set -eu
   cd /integration
   script/setup
   mono bootstrap
-  mono build
+  mono build --package=@appsignal/types,@appsignal/core,@appsignal/javascript
 )
 
 cd /app
 
 echo "Install dependencies"
 yarn install
-yarn link @appsignal/types @appsignal/javascript
+yarn link @appsignal/types @appsignal/core @appsignal/javascript
 
 echo "Starting app"
 yarn server

--- a/javascript/vue-2/commands/run.sh
+++ b/javascript/vue-2/commands/run.sh
@@ -6,14 +6,14 @@ set -eu
   cd /integration
   script/setup
   mono bootstrap
-  mono build
+  mono build --package=@appsignal/types,@appsignal/core,@appsignal/vue,@appsignal/javascript
 )
 
 cd /app
 
 echo "Install dependencies"
 yarn install
-yarn link @appsignal/vue @appsignal/javascript
+yarn link @appsignal/types @appsignal/core @appsignal/vue @appsignal/javascript
 
 echo "Run server"
 yarn serve

--- a/javascript/vue-3/commands/run.sh
+++ b/javascript/vue-3/commands/run.sh
@@ -6,14 +6,14 @@ set -eu
   cd /integration
   script/setup
   mono bootstrap
-  mono build
+  mono build --package=@appsignal/types,@appsignal/core,@appsignal/vue,@appsignal/javascript
 )
 
 cd /app
 
 echo "Install dependencies"
 yarn install
-yarn link @appsignal/vue @appsignal/javascript
+yarn link @appsignal/types @appsignal/core @appsignal/vue @appsignal/javascript
 
 echo "Run server"
 yarn serve

--- a/javascript/webpack/commands/run
+++ b/javascript/webpack/commands/run
@@ -6,14 +6,14 @@ set -eu
   cd /integration
   script/setup
   mono bootstrap
-  mono build
+  mono build --package=@appsignal/types,@appsignal/core,@appsignal/javascript,@appsignal/plugin-window-events,@appsignal/webpack
 )
 
 cd /app
 
 echo "Install dependencies"
 yarn install
-yarn link @appsignal/types @appsignal/javascript @appsignal/plugin-window-events @appsignal/webpack
+yarn link @appsignal/types @appsignal/core @appsignal/javascript @appsignal/plugin-window-events @appsignal/webpack
 
 npm install -g http-server
 


### PR DESCRIPTION
[As suggested by @tombruijn in #51](https://github.com/appsignal/test-setups/pull/51#discussion_r793448102), pass to `mono build` the list of packages that are actually needed, instead of building the whole integration. In addition, ensure that `@appsignal/types` and `@appsignal/core` are always built and linked with `yarn link`, as the other packages depend on them.