### PR TITLE
Fix jruby-Rails6 CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -55,7 +55,7 @@ blocks:
             - "rake app=nodejs/next-js app:test"
         - name: ruby/jruby-rails6
           commands:
-            - "rake app=ruby/padrino app:test"
+            - "rake app=ruby/jruby-rails6 app:test"
         - name: ruby/padrino
           commands:
             - "rake app=ruby/padrino app:test"

--- a/ruby/jruby-rails6/app/config/application.rb
+++ b/ruby/jruby-rails6/app/config/application.rb
@@ -11,6 +11,8 @@ module App
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.hosts << "app"
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
The jruby-rails6 was running the Padrino tests by mistake. This commits
updates it to run its own tests.

[skip review]