### PR TITLE
Fix broken Node builds

### DIFF
--- a/nodejs/express-apollo/Dockerfile
+++ b/nodejs/express-apollo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.5-buster
+FROM node:16.15-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-05-05

--- a/nodejs/express-apollo/Dockerfile
+++ b/nodejs/express-apollo/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y ruby
 # Update npm
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=/home/node/.npm-global/bin:$PATH
-RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm
+RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@8.5.3
 
 # Configure mono
 ENV PATH=/root/mono/bin:$PATH

--- a/nodejs/koa/Dockerfile
+++ b/nodejs/koa/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.5-buster
+FROM node:16.15-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-03-18-1

--- a/nodejs/koa/Dockerfile
+++ b/nodejs/koa/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y postgresql-client ruby
 # Update npm
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=/home/node/.npm-global/bin:$PATH
-RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm
+RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@8.5.3
 
 # Configure mono
 ENV PATH=/root/mono/bin:$PATH

--- a/nodejs/next-js/Dockerfile
+++ b/nodejs/next-js/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.5-buster
+FROM node:16.15-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-02-05

--- a/nodejs/next-js/Dockerfile
+++ b/nodejs/next-js/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y postgresql-client ruby
 # Update npm
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=/home/node/.npm-global/bin:$PATH
-RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm
+RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@8.5.3
 
 # Configure mono
 ENV PATH=/root/mono/bin:$PATH


### PR DESCRIPTION
This PR fixes the builds for the `express-apollo`, `koa` and `next-js` test setups, which are currently broken on main.

### [Pin broken builds to npm version 7](https://github.com/appsignal/test-setups/commit/c16e5188764ac2138ccc84fcb89ab6687f6bbd56)

Using npm version 7 seems to avoid a bug where the build for the `@appsignal/nodejs` package is not ran before `npm install`, causing the installation to fail as it depends on the Transmitter, which needs to be transpiled first.

The bug seems similar to npm/cli#4552, although that seems to be fixed in npm 8.10.0, and upgrading to that version did not fix the problem. I have been unable to reproduce the bug outside of Semaphore CI, which further complicates investigating it.

### [Update Node 15 builds to nearest Node LTS](https://github.com/appsignal/test-setups/commit/411cdce9945db9011a07742bd51f9e15f6834580)

Node 15 is deprecated, so npm loudly complains about it during the installation process. This is not, in itself, the cause of the broken builds, but it is misleading and pollutes the output.

This commit upgrades all Node-based Dockerfiles to Node 16.

