### PR TITLE
Add Phoenix LiveView instrumentation

### DIFF
--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example/application.ex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example/application.ex
@@ -6,6 +6,8 @@ defmodule AppsignalPhoenixExample.Application do
   use Application
 
   def start(_type, _args) do
+    Appsignal.Phoenix.LiveView.attach()
+
     children = [
       # Start the Ecto repository
       AppsignalPhoenixExample.Repo,


### PR DESCRIPTION
This PR adds LiveView instrumentation implemented in appsignal/appsignal-elixir-phoenix#46 to the Phoenix example, as described in the documentation added in appsignal/appsignal-docs#617. This should be merged after those PRs are merged.