### PR TITLE
Add plugins to the vanilla test setup

### DIFF
--- a/javascript/vanilla/README.md
+++ b/javascript/vanilla/README.md
@@ -1,5 +1,12 @@
 # Vanilla JavaScript test app
 
+This setup tests the core front-end integration, as well as the framework-independent plugins:
+
+- `plugin-path-decorator`
+- `plugin-window-events`
+- `plugin-breadcrumbs-console`
+- `plugin-breadcrumbs-network`
+
 ## Setup
 
 - Create a front-end app on [AppSignal.com](https://appsignal.com/redirect-to/organization?to=sites/new).

--- a/javascript/vanilla/app/build.js
+++ b/javascript/vanilla/app/build.js
@@ -7,16 +7,25 @@ esbuild.build({
   bundle: true,
   format: "esm",
   minify: true,
+  keepNames: true,
   sourcemap: true,
   outfile: "dist/app.js",
   define: {
     // Include AppSignal app front-end key in build assets
     "APPSIGNAL_FRONTEND_KEY": JSON.stringify(process.env.APPSIGNAL_FRONTEND_KEY)
   }
-}).then(() =>
-  // Copy the src/index.html file to the dist directory so it can be served by
-  // the HTTP server
-  copyFileSync("src/index.html", "dist/index.html")
-).catch(() =>
+}).then(() => {
+  // Copy the static files from the src directory to the dist directory
+  // so it can be served by the HTTP server
+  const STATIC_FILES = [
+    "index.html",
+    "something.html",
+    "style.css"
+  ]
+
+  STATIC_FILES.forEach((filename) =>
+    copyFileSync(`src/${filename}`, `dist/${filename}`)
+  )
+}).catch(() =>
   process.exit(1)
 );

--- a/javascript/vanilla/app/package.json
+++ b/javascript/vanilla/app/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "dependencies": {
     "@appsignal/javascript": "^1.3.17",
+    "@appsignal/plugin-window-events": "^1.0.17",
+    "@appsignal/plugin-path-decorator": "^1.0.15",
+    "@appsignal/plugin-breadcrumbs-console": "^1.1.24",
+    "@appsignal/plugin-breadcrumbs-network": "^1.1.21",
     "esbuild": "^0.13.3",
     "http-server": "^13.0.2"
   },

--- a/javascript/vanilla/app/src/app.js
+++ b/javascript/vanilla/app/src/app.js
@@ -1,17 +1,46 @@
 import appsignal from "./appsignal";
 
+function addOutput(message) {
+  const output = document.getElementById("output")
+
+  const line = document.createElement("code")
+  line.innerText = `[${(new Date).toISOString()}] ${message}`
+
+  output.appendChild(line)
+
+  output.scrollTop = output.scrollHeight
+}
+
+class NamedError extends Error {
+  // Because JS errors predate JS classes, errors have a `name` property on
+  // their prototype. JS classes, on the other hand, have a `constructor.name`
+  // property on their prototype. So if you want the `name` property of an
+  // error to match the name of its class, you have to do this.
+
+  constructor(message) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
+class TestSendErrorArguments extends NamedError {}
+class TestSendErrorNamespace extends NamedError {}
+class TestSendErrorCallback extends NamedError {}
+class TestSendErrorWrap extends NamedError {}
+
 window.testSendError = function() {
-  console.log("Sending error with Appsignal.sendError");
+  addOutput("Sending some errors with Appsignal.sendError");
+  
   appsignal.sendError(
-    new Error("sendError arguments test"),
+    new TestSendErrorArguments("error message"),
     { arguments: "only tags", tag1: "value 1", tag2: "value 2" }
   )
   appsignal.sendError(
-    new Error("sendError arguments test"),
+    new TestSendErrorNamespace("error message"),
     { arguments: "tags and namespace", tag1: "value 1", tag2: "value 2" },
     "custom"
   )
-  appsignal.sendError(new Error("sendError callback test"), function(span) {
+  appsignal.sendError(new TestSendErrorCallback("error message"), function(span) {
     span.setAction("SendErrorTestAction");
     span.setNamespace("frontend");
     span.setTags({ arguments: "callback", foo: "bar", key: "value" });
@@ -19,13 +48,68 @@ window.testSendError = function() {
 
   try {
     appsignal.wrap(function() {
-      throw new Error("sendError wrap test")
+      throw new TestSendErrorWrap("error message")
     }, function(span) {
       span.setAction("SendErrorWrapAction");
       span.setNamespace("frontend");
       span.setTags({ arguments: "wrap fn", foo: "bar", key: "value" });
     })
   } catch(e) {
-    console.error("Error caught: ", e)
+    addOutput("Wrap test error caught")
   }
 };
+
+class TestOnError extends NamedError {}
+
+window.testOnError = function() {
+  addOutput("Throwing an error for the onError handler");
+  
+  throw new TestOnError("error message");
+}
+
+class TestOnUnhandledRejection extends NamedError {}
+
+window.testOnUnhandledRejection = function() {
+  addOutput("Rejecting some promises for the onUnhandledRejection handler");
+  
+  new Promise((_resolve, reject) => {
+    reject(new TestOnUnhandledRejection("error message"))
+  })
+
+  new Promise((_resolve, reject) => {
+    reject({"onUnhandledRejection": "test object"})
+  })
+
+  new Promise((_resolve, reject) => {
+    reject("onUnhandledRejection test string")
+  })
+}
+
+class TestConsoleBreadcrumbs extends NamedError {}
+
+window.testConsoleBreadcrumbs = function() {
+  addOutput("Sending an error with some console breadcrumbs");
+  
+  console.log("Logging something")
+  console.warn("Warning about something")
+
+  appsignal.sendError(new TestConsoleBreadcrumbs("error message"))
+}
+
+class TestNetworkBreadcrumbs extends NamedError {}
+
+window.testNetworkBreadcrumbs = function() {
+  addOutput("Sending an error with some network breadcrumbs");
+
+  fetch("https://pokeapi.co/api/v2/pokemon/ditto").then((_response) => {
+    addOutput("Fetched some network resource")
+    appsignal.sendError(new TestNetworkBreadcrumbs("error message"))
+  })
+}
+
+class TestPathDecorator extends NamedError {}
+
+window.testPathDecorator = function() {
+  addOutput("Sending an error with the current path")
+  appsignal.sendError(new TestPathDecorator("path decorator test"))
+}

--- a/javascript/vanilla/app/src/appsignal.js
+++ b/javascript/vanilla/app/src/appsignal.js
@@ -1,5 +1,17 @@
 import Appsignal from "@appsignal/javascript";
+import { plugin as networkBreadcrumbs } from "@appsignal/plugin-breadcrumbs-network"
+import { plugin as consoleBreadcrumbs } from "@appsignal/plugin-breadcrumbs-console"
+import { plugin as windowEvents } from "@appsignal/plugin-window-events"
+import { plugin as pathDecorator } from "@appsignal/plugin-path-decorator"
 
-export default new Appsignal({
+const appsignal = new Appsignal({
   key: APPSIGNAL_FRONTEND_KEY
 });
+
+appsignal.use(networkBreadcrumbs());
+appsignal.use(consoleBreadcrumbs());
+appsignal.use(windowEvents());
+appsignal.use(pathDecorator());
+
+export default appsignal;
+

--- a/javascript/vanilla/app/src/index.html
+++ b/javascript/vanilla/app/src/index.html
@@ -6,6 +6,7 @@
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <script src="app.js"></script>
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <h1>Example JavaScript vanilla app</h1>
@@ -14,8 +15,33 @@
 
     <p>This creates a very basic environment to test the AppSignal package in.</p>
 
+    <h2>Output</h2>
+
+    <div id="output">
+      <code>Output from test actions will show up below this message...</code>
+    </div>
+
+    <h2>Core functionality</h2> 
+
     <button onclick="testSendError()">Test <code>sendError</code></button>
 
-    <p><em>Open the web developer console to see if the test succeeded.</em></p>
+    <h2><code>plugin-window-events</code></h2>
+
+    <button onclick="testOnError()">Test <code>onError</code> handler</button>
+    <button onclick="testOnUnhandledRejection()">Test <code>onUnhandledRejection</code> handler</button>
+
+    <h2><code>plugin-path-decorator</code></h2>
+
+    <button onclick="testPathDecorator()">Test path decorator</button>
+
+    The button above just submits an error. <a href="something.html">Go to a different page to see that the pathname submitted is different for the same error.</a>
+
+    <h2><code>plugin-breadcrumbs-console</code></h2>
+
+    <button onclick="testConsoleBreadcrumbs()">Test console breadcrumbs</code></button>
+
+    <h2><code>plugin-breadcrumbs-network</code></h2>
+
+    <button onclick="testNetworkBreadcrumbs()">Test network breadcrumbs</code></button>
   </body>
 </html>

--- a/javascript/vanilla/app/src/something.html
+++ b/javascript/vanilla/app/src/something.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+    <meta charset="utf-8">
+    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <script src="app.js"></script>
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <h1>A different page <a href="index.html">(go back)</a></h1>
+
+    <button onclick="testPathDecorator()">Test path decorator</button>
+
+    <h2>Output</h2>
+
+    <div id="output">
+      <code>Output from test actions will show up below this message...</code>
+    </div>
+  </body>
+</html>

--- a/javascript/vanilla/app/src/style.css
+++ b/javascript/vanilla/app/src/style.css
@@ -1,0 +1,13 @@
+button {
+  display: block;
+}
+
+#output code {
+  display: block;
+}
+
+#output {
+  width: auto;
+  height: 6em;
+  overflow: scroll;
+}


### PR DESCRIPTION
This commit adds support for the framework-independent plugins to the vanilla test setup. It provides a simple interface for testing the behaviour of `plugin-window-events`, `plugin-path-decorator`, `plugin-breadcrumbs-console` and `plugin-breadcrumbs-network`.

Since the console breadcrumbs plugin instruments `console.log`, the feedback from the test buttons is now shown through a dedicated "Output" section in the page.

Since there are many different errors reported from the same buttons in the same app, each error now has its own named subclass. This makes it easy to tell them apart in AppSignal's UI.

This should allow for proper testing of appsignal/appsignal-javascript#575.