### PR TITLE
Add Finch test endpoint

### DIFF
--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example/application.ex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example/application.ex
@@ -16,9 +16,11 @@ defmodule AppsignalPhoenixExample.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: AppsignalPhoenixExample.PubSub},
       # Start the Endpoint (http/https)
-      AppsignalPhoenixExampleWeb.Endpoint
+      AppsignalPhoenixExampleWeb.Endpoint,
       # Start a worker by calling: AppsignalPhoenixExample.Worker.start_link(arg)
       # {AppsignalPhoenixExample.Worker, arg}
+      # Start Finch HTTP client
+      {Finch, name: MyFinch}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/controllers/page_controller.ex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/controllers/page_controller.ex
@@ -19,4 +19,13 @@ defmodule AppsignalPhoenixExampleWeb.PageController do
   def error(_conn, _params) do
     raise "This is a Phoenix error!"
   end
+
+  def finch(conn, _params) do
+    {:ok, response} = Finch.build(:get, "http://hex.pm") |> Finch.request(MyFinch)
+    text(
+      conn,
+      "Performed an HTTP request using Finch: " <>
+      "response status code is #{response.status}"
+    )
+  end
 end

--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/router.ex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/router.ex
@@ -19,6 +19,7 @@ defmodule AppsignalPhoenixExampleWeb.Router do
     get "/", PageController, :index
     get "/slow", PageController, :slow
     get "/error", PageController, :error
+    get "/finch", PageController, :finch
     resources "/users", UserController
   end
 

--- a/elixir/phoenix-example/app/mix.exs
+++ b/elixir/phoenix-example/app/mix.exs
@@ -51,7 +51,8 @@ defmodule AppsignalPhoenixExample.MixProject do
       {:plug_cowboy, "~> 2.0"},
       {:appsignal, path: "#{integration_path()}/appsignal-elixir", override: true},
       {:appsignal_plug, path: "#{integration_path()}/appsignal-elixir-plug", override: true},
-      {:appsignal_phoenix, path: "#{integration_path()}/appsignal-elixir-phoenix", override: true}
+      {:appsignal_phoenix, path: "#{integration_path()}/appsignal-elixir-phoenix", override: true},
+      {:finch, "~> 0.13"}
     ]
   end
 


### PR DESCRIPTION
Adds a test endpoint for Finch to the `phoenix-example` app. Useful for reviewing appsignal/appsignal-elixir#794.