### PR TITLE
Fix Webmachine test setup

### DIFF
--- a/ruby/webmachine/app/Gemfile
+++ b/ruby/webmachine/app/Gemfile
@@ -5,3 +5,4 @@ gem "i18n", "~> 0.0" # Lock to pre 1.x version as it's not compatible
 gem "webrick"
 gem "appsignal", :path => "/integration"
 gem "pry"
+gem "rackup"


### PR DESCRIPTION
### Add rackup to Gemfile

This fixes the failure to run in the `ruby/webmachine` test setup on newer Ruby versions.