### PR TITLE
Fix Node.js apps by pinning them to 2.4 branch

### DIFF
--- a/nodejs/esbuild-express/commands/run
+++ b/nodejs/esbuild-express/commands/run
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  git checkout 2-4-stable
   script/setup
   mono bootstrap
   mono clean

--- a/nodejs/express-apollo/commands/prepare
+++ b/nodejs/express-apollo/commands/prepare
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  git checkout 2-4-stable
   script/setup
   source ~/.bashrc
   mono bootstrap

--- a/nodejs/express-postgres/commands/run
+++ b/nodejs/express-postgres/commands/run
@@ -15,6 +15,7 @@ psql $host \
 echo "Install, link and build integration"
 (
   cd /integration
+  git checkout 2-4-stable
   script/setup
   mono bootstrap
   mono clean

--- a/nodejs/express-redis/commands/run
+++ b/nodejs/express-redis/commands/run
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  git checkout 2-4-stable
   script/setup
   mono bootstrap
   mono clean

--- a/nodejs/koa/commands/prepare
+++ b/nodejs/koa/commands/prepare
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  git checkout 2-4-stable
   script/setup
   mono bootstrap
   mono build

--- a/nodejs/next-js/commands/prepare
+++ b/nodejs/next-js/commands/prepare
@@ -5,6 +5,7 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
+  git checkout 2-4-stable
   script/setup
   mono bootstrap
   mono build


### PR DESCRIPTION
These apps are designed to work on Node.js 2.x, not Node.js 3.x. We have a different set of apps as integration tests for 3.x in the repository itself.