### PR TITLE
Fix Phoenix test setup

### DIFF
--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web.ex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web.ex
@@ -92,7 +92,7 @@ defmodule AppsignalPhoenixExampleWeb do
       use Phoenix.HTML
 
       # Import LiveView and .heex helpers (live_render, live_patch, <.form>, etc)
-      import Phoenix.LiveView.Helpers
+      import Phoenix.Component
 
       # Import basic rendering functionality (render, render_layout, etc)
       import Phoenix.View

--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/templates/layout/root.html.heex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/templates/layout/root.html.heex
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="csrf-token" content={csrf_token_value()}>
-    <%= live_title_tag assigns[:page_title] || "AppsignalPhoenixExample", suffix: " · Phoenix Framework" %>
+    <.live_title suffix=" · Phoenix Framework">
+      <%= assigns[:page_title] || "AppsignalPhoenixExample" %>
+    </.live_title>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")}/>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>

--- a/elixir/phoenix-example/app/mix.exs
+++ b/elixir/phoenix-example/app/mix.exs
@@ -43,7 +43,7 @@ defmodule AppsignalPhoenixExample.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:phoenix_html, "~> 3.0"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
-      {:phoenix_live_view, "~> 0.17.5"},
+      {:phoenix_live_view, "~> 0.18"},
       {:floki, ">= 0.30.0", only: :test},
       {:phoenix_live_dashboard, "~> 0.6"},
       {:esbuild, "~> 0.4", runtime: Mix.env() == :dev},


### PR DESCRIPTION
### Bump phoenix_live_view dependency

Update `phoenix_live_view` to work with newer `phoenix` versions.

Change where `live_flash` is imported from, as it has been moved
in LiveView 0.18 from `Phoenix.LiveView.Helpers` to `Phoenix.Component`.

Use the new `<.live_title>` component instead of the deprecated
<%= live_title_tag %> helper.