### PR TITLE
Fix Sidekiq app using version 6

### DIFF
--- a/ruby/rails6-sidekiq/app/Gemfile
+++ b/ruby/rails6-sidekiq/app/Gemfile
@@ -15,7 +15,7 @@ gem 'listen'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
-gem 'sidekiq'
+gem 'sidekiq', "~> 6.5.8"
 
 gem 'appsignal', :path => "/integration"
 gem "excon"


### PR DESCRIPTION
Lock the version to version 6 so that it doesn't use version 7.