### PR TITLE
Configure app port to always be 4001

### DIFF
--- a/nodejs/esbuild-express/app/src/app.js
+++ b/nodejs/esbuild-express/app/src/app.js
@@ -30,6 +30,6 @@ app.get('/slow', async (_req, res) => {
 
 app.use(expressErrorHandler(appsignal));
 
-app.listen(3000, () => {
+app.listen(process.env.PORT, () => {
   console.log('Example app listening')
 });

--- a/nodejs/esbuild-express/docker-compose.yml
+++ b/nodejs/esbuild-express/docker-compose.yml
@@ -5,8 +5,9 @@ services:
     build: .
     image: nodejs/esbuild-express
     ports:
-      - "4001:3000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=nodejs-express-redis
     env_file:
       - ../../appsignal.env
@@ -23,4 +24,4 @@ services:
       - app
     environment:
       - APP_NAME=nodejs/express-redis
-      - APP_URL=http://app:3000
+      - APP_URL=http://app:4001

--- a/nodejs/express-postgres/app/app.js
+++ b/nodejs/express-postgres/app/app.js
@@ -65,6 +65,6 @@ app.get('/slow', async (_req, res) => {
 
 app.use(expressErrorHandler(appsignal));
 
-app.listen(3000, () => {
+app.listen(process.env.PORT, () => {
   console.log('Example app listening')
 })

--- a/nodejs/express-postgres/docker-compose.yml
+++ b/nodejs/express-postgres/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     depends_on:
       - postgres
     ports:
-      - "4001:3000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=nodejs-express-postgres
     env_file:
       - postgres.env
@@ -30,4 +31,4 @@ services:
       - app
     environment:
       - APP_NAME=nodejs/express-postgres
-      - APP_URL=http://app:3000
+      - APP_URL=http://app:4001

--- a/nodejs/express-redis/app/app.js
+++ b/nodejs/express-redis/app/app.js
@@ -63,6 +63,6 @@ app.get('/slow', async (_req, res) => {
 
 app.use(expressErrorHandler(appsignal));
 
-app.listen(3000, () => {
+app.listen(process.env.PORT, () => {
   console.log('Example app listening')
 });

--- a/nodejs/express-redis/docker-compose.yml
+++ b/nodejs/express-redis/docker-compose.yml
@@ -10,8 +10,9 @@ services:
     depends_on:
       - redis
     ports:
-      - "4001:3000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=nodejs-express-redis
     env_file:
       - ../../appsignal.env
@@ -28,4 +29,4 @@ services:
       - app
     environment:
       - APP_NAME=nodejs/express-redis
-      - APP_URL=http://app:3000
+      - APP_URL=http://app:4001

--- a/nodejs/koa/app/app.js
+++ b/nodejs/koa/app/app.js
@@ -53,4 +53,4 @@ app
   .use(router.routes())
   .use(router.allowedMethods());
 
-app.listen(3000);
+app.listen(process.env.PORT);

--- a/nodejs/koa/docker-compose.yml
+++ b/nodejs/koa/docker-compose.yml
@@ -5,8 +5,9 @@ services:
     build: .
     image: nodejs/koa
     ports:
-      - "4001:3000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=nodejs-koa
     env_file:
       - ../../appsignal.env
@@ -23,4 +24,4 @@ services:
       - app
     environment:
       - APP_NAME=nodejs/koa
-      - APP_URL=http://app:3000
+      - APP_URL=http://app:4001

--- a/support/templates/skeleton/docker-compose.yml.erb
+++ b/support/templates/skeleton/docker-compose.yml.erb
@@ -5,8 +5,9 @@ services:
     build: .
     image: <%= @app %>
     ports:
-      - "4001:3000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=<%= @app.gsub('/', '-') %>
     env_file:
       - ../../appsignal.env
@@ -23,4 +24,4 @@ services:
       - app
     environment:
       - APP_NAME=<%= @app %>
-      - APP_URL=http://app:3000
+      - APP_URL=http://app:4001


### PR DESCRIPTION
The difference between the Docker compose internal network port and the port exposed to the outside has tripped me up more than once. For instance when the container output says something like: "The app is ready at 127.0.0.0:3000", but it's not.

Let's use the same port everywhere. Configure the PORT env var by default, because we need to configure the port for some apps manually anyway, and others listen the this PORT env var.