### PR TITLE
Add Express + Redis + V3 + Alpine test setup

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -76,6 +76,9 @@ blocks:
         - name: nodejs/express-redis-v3
           commands:
             - "rake app=nodejs/express-redis-v3 app:test"
+        - name: nodejs/express-redis-v3-alpine
+          commands:
+            - "rake app=nodejs/express-redis-v3-alpine app:test"
         - name: nodejs/koa
           commands:
             - "rake app=nodejs/koa app:test"

--- a/nodejs/express-redis-v3-alpine/Dockerfile
+++ b/nodejs/express-redis-v3-alpine/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:17-buster
+
+# Update this if the docker image changes
+ENV REFRESHED_AT=2022-01-25
+
+# Install dependencies
+RUN apt-get update && apt-get install -y redis ruby
+
+# Update npm
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=/home/node/.npm-global/bin:$PATH
+RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@7
+
+# Configure mono
+ENV PATH=/root/mono/bin:$PATH
+
+# Copy commands into the container
+RUN mkdir /commands
+COPY ./commands/* /commands/
+RUN chmod +x /commands/*
+
+# Run prepare and start processmon
+CMD /commands/run

--- a/nodejs/express-redis-v3-alpine/Dockerfile
+++ b/nodejs/express-redis-v3-alpine/Dockerfile
@@ -6,6 +6,9 @@ ENV REFRESHED_AT=2022-01-25
 # Install mono and setup script dependencies
 RUN apk add --no-cache ruby bash git curl
 
+# Disable safe directory checks on newer Git
+RUN git config --global --add safe.directory '*'
+
 # Install integration build dependencies
 RUN apk add --no-cache python3 make g++
 

--- a/nodejs/express-redis-v3-alpine/Dockerfile
+++ b/nodejs/express-redis-v3-alpine/Dockerfile
@@ -1,10 +1,13 @@
-FROM node:17-buster
+FROM node:17-alpine
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2022-01-25
 
-# Install dependencies
-RUN apt-get update && apt-get install -y redis ruby
+# Install mono and setup script dependencies
+RUN apk add --no-cache ruby bash git curl
+
+# Install integration build dependencies
+RUN apk add --no-cache python3 make g++
 
 # Update npm
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global

--- a/nodejs/express-redis-v3-alpine/README.md
+++ b/nodejs/express-redis-v3-alpine/README.md
@@ -1,0 +1,3 @@
+# Test application using Redis as the main DB.
+
+Run it following the standard commands described in the root README.

--- a/nodejs/express-redis-v3-alpine/app/app.js
+++ b/nodejs/express-redis-v3-alpine/app/app.js
@@ -1,0 +1,66 @@
+const { expressErrorHandler } = require("@appsignal/nodejs");
+const { createClient } = require("redis");
+const bodyParser = require("body-parser");
+const express = require("express");
+
+const app = express();
+app.set("view engine", "pug");
+app.use(bodyParser.urlencoded({extended: true}));
+
+// Initialize Redis
+const redisCli = createClient({url: "redis://redis:6379"});
+redisCli.connect();
+
+app.get("/", (req, res) => {
+  (async () => {
+    console.log("Request on /");
+
+    const keys = await redisCli.keys("posts:*");
+    let posts = [];
+
+    for (const key of keys) {
+      const post = await redisCli.hGetAll(key);
+      await posts.push(post);
+    }
+
+    await res.render("index", {posts: posts});
+
+  })();
+});
+
+app.get("/new", (req, res) => {
+  console.log("Request on /new");
+
+  res.render("new", {});
+});
+
+app.post("/create", (req, res) => {
+  (async () => {
+    console.log("Request on /create");
+    const { title, text } = req.body;
+    const id = await redisCli.incr("postIds");
+
+    await redisCli.sendCommand(
+      ["HMSET", `posts:${id}`, "title", title, "text", text]
+    );
+
+    res.redirect("/");
+  })();
+});
+
+app.get("/error", (req, res) => {
+  console.log("Request on /error");
+
+  throw new Error("Error in the redis express app");
+});
+
+app.get('/slow', async (_req, res) => {
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  res.send("Well, that took forever!");
+});
+
+app.use(expressErrorHandler());
+
+app.listen(process.env.PORT, () => {
+  console.log('Example app listening')
+});

--- a/nodejs/express-redis-v3-alpine/app/appsignal.cjs
+++ b/nodejs/express-redis-v3-alpine/app/appsignal.cjs
@@ -1,0 +1,9 @@
+const { Appsignal } = require("@appsignal/nodejs");
+
+// Gets the config from the environment
+const appsignal = new Appsignal({
+  "active": true
+});
+
+console.log("Starting appsignal");
+console.log(appsignal);

--- a/nodejs/express-redis-v3-alpine/app/package.json
+++ b/nodejs/express-redis-v3-alpine/app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "express-redis",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "server": "node --require ./appsignal.cjs app.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@appsignal/nodejs": "*",
+    "express": "4.17.1",
+    "pug": "*",
+    "redis": "*"
+  }
+}

--- a/nodejs/express-redis-v3-alpine/app/processmon.toml
+++ b/nodejs/express-redis-v3-alpine/app/processmon.toml
@@ -1,0 +1,15 @@
+[[paths_to_watch]]
+path = "/app"
+
+[[paths_to_watch]]
+path = "/integration"
+
+[processes.node]
+command = "npm"
+args = ["run", "server"]
+working_dir = "/app"
+
+[triggers.build_integration]
+command = "mono"
+args = ["build"]
+working_dir = "/integration"

--- a/nodejs/express-redis-v3-alpine/app/views/index.pug
+++ b/nodejs/express-redis-v3-alpine/app/views/index.pug
@@ -1,0 +1,17 @@
+html
+  head
+    title Posts
+  body
+    h1 Posts
+
+    each post in posts
+      section
+        h2= post.title
+        p= post.text
+    else
+      p No posts
+
+    p
+      a(href='/new') New post
+    p
+      a(href='/error') Trigger an error

--- a/nodejs/express-redis-v3-alpine/app/views/new.pug
+++ b/nodejs/express-redis-v3-alpine/app/views/new.pug
@@ -1,0 +1,17 @@
+html
+  head
+    title New post
+  body
+    h1 Create a new post
+
+  form(method='post' action='/create')
+    p
+      label(for='title') Title
+      br
+      input(type='text' name='title')
+    p
+      label(for='text') Text
+      br
+      textarea(rows='8' cols='60' name='text')
+    p
+      input(type='submit' name='Create post')

--- a/nodejs/express-redis-v3-alpine/commands/run
+++ b/nodejs/express-redis-v3-alpine/commands/run
@@ -6,6 +6,7 @@ echo "Install, link and build integration"
 (
   cd /integration
   git checkout main
+  touch ~/.bashrc # hack to make the mono installer happy
   script/setup
   mono bootstrap
   mono clean

--- a/nodejs/express-redis-v3-alpine/commands/run
+++ b/nodejs/express-redis-v3-alpine/commands/run
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+echo "Install, link and build integration"
+(
+  cd /integration
+  git checkout main
+  script/setup
+  mono bootstrap
+  mono clean
+  mono run -- npm run install
+  mono build
+)
+
+cd /app
+
+echo "Install dependencies"
+npm install
+
+echo "Npm link in app"
+npm link @appsignal/nodejs
+
+echo "Starting app"
+/commands/processmon processmon.toml

--- a/nodejs/express-redis-v3-alpine/docker-compose.yml
+++ b/nodejs/express-redis-v3-alpine/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis
+
+  app:
+    build: .
+    image: nodejs/express-redis
+    depends_on:
+      - redis
+    ports:
+      - "4001:4001"
+    environment:
+      - PORT=4001
+      - APPSIGNAL_APP_NAME=nodejs-express-redis-v3-alpine
+    env_file:
+      - ../../appsignal.env
+      - ../../appsignal_key.env
+    volumes:
+      - ./app:/app
+      - ../integration:/integration
+  tests:
+    build: ../../support/server-tests
+    image: server-tests
+    profiles:
+      - tests
+    depends_on:
+      - app
+    environment:
+      - APP_NAME=nodejs/express-redis-v3-alpine
+      - APP_URL=http://app:4001

--- a/nodejs/express-redis-v3/docker-compose.yml
+++ b/nodejs/express-redis-v3/docker-compose.yml
@@ -28,5 +28,5 @@ services:
     depends_on:
       - app
     environment:
-      - APP_NAME=nodejs/express-redis
+      - APP_NAME=nodejs/express-redis-v3
       - APP_URL=http://app:4001


### PR DESCRIPTION
### [Amend tests' app name in express-redis-v3](https://github.com/appsignal/test-setups/commit/21b2f828d71ac37ef573a30e16748e8add541de5)

This makes it clearer to see which apps' tests are being ran.

### [Copy express-redis-v3 project as -alpine](https://github.com/appsignal/test-setups/commit/45c5cd6aabb46dff9154eb69e7b1f79816ee30c0)

Nothing interesting to see in this commit -- this is a separate
commit so the diff with the next commit is nicer.

### [Change express-redis-v3-alpine to use Alpine](https://github.com/appsignal/test-setups/commit/850d9d502d93f68b6fdf486456731bf14868dc96)

This commit actually implements the changes needed to use an
Alpine image instead of a Debian-based image.