### PR TITLE
Add NGINX standalone test setup

### DIFF
--- a/standalone/nginx/commands/.gitkeep
+++ b/standalone/nginx/commands/.gitkeep
@@ -1,0 +1,2 @@
+This folder exists so that the Rake tasks can copy processmon into it.
+Processmon is not used in this test setup.

--- a/standalone/nginx/docker-compose.yml
+++ b/standalone/nginx/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  nginx:
+    build: nginx
+    ports:
+      - "3001:3001"
+    links:
+      - agent
+    volumes:
+      - ./app:/app
+
+  agent:
+    image: appsignal/agent:latest
+    environment:
+      - APPSIGNAL_APP_NAME=nginx-metrics-standalone-test
+      - APPSIGNAL_APP_ENV=development
+      - APPSIGNAL_LOG_LEVEL=trace
+    env_file:
+      - ../../appsignal_key.env

--- a/standalone/nginx/nginx/Dockerfile
+++ b/standalone/nginx/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:latest
+
+COPY ./conf.d/* /etc/nginx/conf.d/

--- a/standalone/nginx/nginx/conf.d/appsignal.conf
+++ b/standalone/nginx/nginx/conf.d/appsignal.conf
@@ -1,0 +1,6 @@
+map '' $appsignal_group {
+  default 'http';
+}
+
+log_format appsignal_metrics '1|g=$appsignal_group;s=$status;rqt=$request_time;rql=$request_length;bs=$bytes_sent;ua=$upstream_addr;uct=$upstream_connect_time;uht=$upstream_header_time;urst=$upstream_response_time;us=$upstream_status;ucs=$upstream_cache_status;ca=$connections_active;cr=$connections_reading;cwr=$connections_writing;cwa=$connections_waiting';
+access_log syslog:server=agent:27649,tag=appsignal_nginx appsignal_metrics;

--- a/standalone/nginx/nginx/conf.d/server.conf
+++ b/standalone/nginx/nginx/conf.d/server.conf
@@ -1,0 +1,51 @@
+upstream backend {
+    # non-existent primary upstream server
+    # should always be used first and always fail
+    server 127.0.0.1:8091 max_fails=0;
+    server 127.0.0.1:8090 backup;
+}
+
+proxy_cache_path /tmp/nginx_cache keys_zone=my_cache:10m max_size=10m 
+                 inactive=5s use_temp_path=off;
+
+server {
+  listen 3001;
+  
+  default_type text/plain;
+
+  location /fail {
+    return 500 "Oh no!";
+  }
+
+  location /proxy {
+    proxy_pass http://backend/;
+  }
+
+  location /cache {
+    proxy_pass http://backend/;
+    proxy_cache my_cache;
+    proxy_cache_lock on;
+  }
+
+  location / {
+    return 200 "Hello world!";
+  }
+}
+
+server {
+  listen 8090;
+
+  add_header Cache-Control "public, max-age=5";
+
+  default_type text/plain;
+  set $appsignal_group proxy;
+  
+  location /fail {
+    return 500 "Oh no!";
+  }
+
+  location / {
+    return 200 "Hello proxy!";
+  }
+}
+


### PR DESCRIPTION
Mostly a copy-paste from https://github.com/appsignal/nginx-metrics-standalone-test/, making use of the new stand-alone agent.

Part of #88 -- after this, archive the original repository and close the issue.