### PR TITLE
Add logging backend to Phoenix app

### DIFF
--- a/elixir/phoenix-example/app/config/runtime.exs
+++ b/elixir/phoenix-example/app/config/runtime.exs
@@ -81,3 +81,10 @@ if config_env() == :prod do
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 end
+
+# Configures AppSignal's logger
+config :logger,
+  backends: [
+    :console,
+    {Appsignal.Logger.Backend, [group: "phoenix"]}
+  ]


### PR DESCRIPTION
This PR adds the logging backend implemented in https://github.com/appsignal/appsignal-elixir/pull/829 to the Phoenix test setup. The tests do not pass at the moment, as CI uses the `main` branch of the Elixir repository instead of the Elixir PR's `logger-backend` branch. They should pass on re-run after the Elixir PR is merged. 