### PR TITLE
Use sparse crates.io protocol in processmon build

### DIFF
--- a/support/processmon/Dockerfile
+++ b/support/processmon/Dockerfile
@@ -1,8 +1,9 @@
-FROM rust:1.67.1-alpine3.16
-
-ENV VERSION=0.4.1
+FROM rust:1.68.1-alpine3.17
 
 RUN apk update
 RUN apk add musl-dev
+
+ENV VERSION=0.4.1
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 RUN cargo install processmon --version=$VERSION

--- a/support/processmon/build.sh
+++ b/support/processmon/build.sh
@@ -4,6 +4,6 @@ set -eu
 
 rm -f processmon
 docker build --platform linux/amd64 -t processmon:latest .
-docker run -i -v ${PWD}:/mount processmon:latest sh -s <<EOF
+docker run --rm -i -v ${PWD}:/mount processmon:latest sh -s <<EOF
   cp /usr/local/cargo/bin/processmon /mount/
 EOF


### PR DESCRIPTION
## Use sparse crates.io protocol in processmon build

Use the sparse protocol for fetching the crates.io registry. Containers
kept running into an Out of Memory error (exit code 137) because it took
up more than 1GB of memory to update the registry.
With the sparse protocol I only saw the entire build peak around 500MB.

## Remove the processmon container after use

Add the `--rm` flag to clean up the container when the processmon binary
is copied from it.
