### PR TITLE
Add Sinatra + GVLTools test setup

### DIFF
--- a/elixir/plug/commands/console
+++ b/elixir/plug/commands/console
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-echo "TODO: Implement starting a console, or remove this file if that's not possible"
-exit 1

--- a/nodejs/express-apollo/commands/console
+++ b/nodejs/express-apollo/commands/console
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-echo "TODO: Implement starting a console, or remove this file if that's not possible"
-exit 1

--- a/ruby/linux-arm/commands/console
+++ b/ruby/linux-arm/commands/console
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-echo "TODO: Implement starting a console, or remove this file if that's not possible"
-exit 1

--- a/ruby/sinatra-gvltools/Dockerfile
+++ b/ruby/sinatra-gvltools/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:3.2
+
+# Update this if the docker image changes
+ENV REFRESHED_AT=2021-06-22
+
+RUN apt-get update && \
+  apt-get install -y less
+
+# Copy commands into the container
+RUN mkdir /commands
+COPY ./commands/* /commands/
+RUN chmod +x /commands/*
+
+# Run the app
+CMD /commands/run

--- a/ruby/sinatra-gvltools/app/Gemfile
+++ b/ruby/sinatra-gvltools/app/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "webrick"
+gem "appsignal", :path => "/integration"
+gem "activesupport", "5.2.0"
+gem "actionmailer", "5.2.0"
+gem "gvltools", "0.2.0"
+
+gem "pry"

--- a/ruby/sinatra-gvltools/app/app.rb
+++ b/ruby/sinatra-gvltools/app/app.rb
@@ -1,0 +1,45 @@
+require "active_support"
+require "action_mailer"
+require "sinatra"
+require "appsignal"
+require "appsignal/integrations/sinatra"
+
+get "/" do
+  time = Time.now.strftime("%H:%M")
+  <<~HTML
+    <h1>Sinatra example app</h1>
+
+    <ul>
+      <li><a href="/slow?time=#{time}">Slow request</a></li>
+      <li><a href="/error?time=#{time}">Error request</a></li>
+      <li><a href="/threads">Spawn threads</a></li>
+    </ul>
+  HTML
+end
+
+def fibonacci(number)
+  number <= 1 ? number : fibonacci(number - 1) + fibonacci(number - 2)
+end
+
+get "/threads" do
+  5.times.map do
+    Thread.new do
+      5.times do
+        fibonacci(30)
+      end
+    end
+  end.each do |thread|
+    thread.join
+  end
+  
+  "Spawned and joined some threads!"
+end
+
+get "/slow" do
+  sleep 3
+  "ZzZzZzZ.."
+end
+
+get "/error" do
+  raise "error"
+end

--- a/ruby/sinatra-gvltools/app/config.ru
+++ b/ruby/sinatra-gvltools/app/config.ru
@@ -1,0 +1,2 @@
+require "./app"
+run Sinatra::Application

--- a/ruby/sinatra-gvltools/app/config/appsignal.yml
+++ b/ruby/sinatra-gvltools/app/config/appsignal.yml
@@ -1,0 +1,11 @@
+default: &defaults
+  debug: true
+
+test:
+  <<: *defaults
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/ruby/sinatra-gvltools/app/processmon.toml
+++ b/ruby/sinatra-gvltools/app/processmon.toml
@@ -1,0 +1,15 @@
+[[paths_to_watch]]
+path = "/app"
+
+[[paths_to_watch]]
+path = "/integration"
+
+[processes.app]
+command = "bundle"
+args = [
+  "exec",
+  "rackup",
+  "--host=0.0.0.0",
+  "--port=4001"
+]
+working_dir = "/app"

--- a/ruby/sinatra-gvltools/commands/console
+++ b/ruby/sinatra-gvltools/commands/console
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+echo "TODO: Implement starting a console, or remove this file if that's not possible"
+exit 1

--- a/ruby/sinatra-gvltools/commands/console
+++ b/ruby/sinatra-gvltools/commands/console
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-echo "TODO: Implement starting a console, or remove this file if that's not possible"
-exit 1

--- a/ruby/sinatra-gvltools/commands/diagnose
+++ b/ruby/sinatra-gvltools/commands/diagnose
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+cd /app
+bundle exec appsignal diagnose --environment=production

--- a/ruby/sinatra-gvltools/commands/run
+++ b/ruby/sinatra-gvltools/commands/run
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eu
+
+echo "Install appsignal"
+(
+  cd /integration
+  rake extension:install
+)
+
+cd /app
+
+echo "Install dependencies"
+bundle config set path vendor/bundle
+bundle install
+
+echo "Starting app"
+/commands/processmon processmon.toml

--- a/ruby/sinatra-gvltools/docker-compose.yml
+++ b/ruby/sinatra-gvltools/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    image: ruby/sinatra
+    ports:
+      - "4001:4001"
+    environment:
+      - APPSIGNAL_APP_NAME=ruby-sinatra-gvltools
+      - PORT=4001
+    env_file:
+      - ../../appsignal.env
+      - ../../appsignal_key.env
+    volumes:
+      - ./app:/app
+      - ../integration:/integration
+  tests:
+    build: ../../support/server-tests
+    image: server-tests
+    profiles:
+      - tests
+    depends_on:
+      - app
+    environment:
+      - APP_NAME=ruby/sinatra-gvltools
+      - APP_URL=http://app:4001

--- a/ruby/sinatra/commands/console
+++ b/ruby/sinatra/commands/console
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-echo "TODO: Implement starting a console, or remove this file if that's not possible"
-exit 1


### PR DESCRIPTION
Adds a test setup for Sinatra that uses Ruby 3.2 and adds GVLTools as a dependency for the project.

See https://github.com/appsignal/appsignal-ruby/pull/931 for context -- check out the branch in that PR in the integration to test this.