### PR TITLE
Remove API key attribute from Node apps

### DIFF
--- a/nodejs/v3/express-apollo/app/src/appsignal.cjs
+++ b/nodejs/v3/express-apollo/app/src/appsignal.cjs
@@ -5,6 +5,5 @@ new Appsignal({
   name: "opentelemetry-express-apollo",
   logLevel: "trace",
   log: "file",
-  logPath: "/tmp",
-  pushApiKey: "not-a-real-api-key"
+  logPath: "/tmp"
 });

--- a/nodejs/v3/express-postgres/app/src/appsignal.cjs
+++ b/nodejs/v3/express-postgres/app/src/appsignal.cjs
@@ -5,6 +5,5 @@ new Appsignal({
   name: "opentelemetry-express-postgres",
   logLevel: "trace",
   log: "file",
-  logPath: "/tmp",
-  pushApiKey: "not-a-real-api-key"
+  logPath: "/tmp"
 });

--- a/nodejs/v3/express-yoga/app/src/appsignal.cjs
+++ b/nodejs/v3/express-yoga/app/src/appsignal.cjs
@@ -5,6 +5,5 @@ new Appsignal({
   name: "opentelemetry-express-yoga",
   logLevel: "trace",
   log: "file",
-  logPath: "/tmp",
-  pushApiKey: "not-a-real-api-key"
+  logPath: "/tmp"
 })

--- a/nodejs/v3/koa-mongo/app/src/appsignal.cjs
+++ b/nodejs/v3/koa-mongo/app/src/appsignal.cjs
@@ -5,6 +5,5 @@ new Appsignal({
   name: "opentelemetry-koa-mongo",
   logLevel: "trace",
   log: "file",
-  logPath: "/tmp",
-  pushApiKey: "not-a-real-api-key"
+  logPath: "/tmp"
 });

--- a/nodejs/v3/koa-mysql/app/src/appsignal.cjs
+++ b/nodejs/v3/koa-mysql/app/src/appsignal.cjs
@@ -5,6 +5,5 @@ new Appsignal({
   name: "opentelemetry-koa-mysql",
   logLevel: "trace",
   log: "file",
-  logPath: "/tmp",
-  pushApiKey: "not-a-real-api-key"
+  logPath: "/tmp"
 });

--- a/nodejs/v3/nestjs-prisma/app/appsignal.cjs
+++ b/nodejs/v3/nestjs-prisma/app/appsignal.cjs
@@ -2,6 +2,5 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "nestjs-prisma-screenshot",
-  pushApiKey: "not-a-real-api-key",
+  name: "nestjs-prisma-screenshot"
 });

--- a/nodejs/v3/restify/app/src/appsignal.cjs
+++ b/nodejs/v3/restify/app/src/appsignal.cjs
@@ -5,6 +5,5 @@ new Appsignal({
   name: "opentelemetry-restify",
   logLevel: "trace",
   log: "file",
-  logPath: "/tmp",
-  pushApiKey: "not-a-real-api-key"
+  logPath: "/tmp"
 });


### PR DESCRIPTION
The Node.js apps no longer have the `pushApiKey` attribute preset when initializing their AppSignal clients.