### PR TITLE
Rails error reporter

### DIFF
--- a/ruby/rails7-sidekiq/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-sidekiq/app/app/controllers/examples_controller.rb
@@ -2,8 +2,15 @@ class ExamplesController < ApplicationController
   def slow
     sleep 3
   end
-  
+
   def error
     raise "This is a Rails error!"
+  end
+
+  def error_reporter
+    Rails.error.handle do
+      1 + '1' # raises TypeError
+    end
+    render :html => "An error has been reported through the Rails error reporter"
   end
 end

--- a/ruby/rails7-sidekiq/app/app/mailers/error_mailer.rb
+++ b/ruby/rails7-sidekiq/app/app/mailers/error_mailer.rb
@@ -1,5 +1,8 @@
 class ErrorMailer < ApplicationMailer
   def test(*args)
+    Rails.error.handle do
+      1 + '1' # raises TypeError
+    end
     @args = args
     mail(
       :to => "test@example.com",

--- a/ruby/rails7-sidekiq/app/app/views/examples/index.html.erb
+++ b/ruby/rails7-sidekiq/app/app/views/examples/index.html.erb
@@ -3,6 +3,7 @@
 <ul>
   <li><%= link_to "Slow request", slow_path %></li>
   <li><%= link_to "Request with error", error_path %></li>
+  <li><%= link_to "Error reporter test", error_reporter_path %></li>
   <li><%= link_to "Sidekiq workers", workers_path %></li>
   <li><%= link_to "Redis queries", redis_path %></li>
   <li><%= link_to "Excon requests", requests_path %></li>

--- a/ruby/rails7-sidekiq/app/app/views/examples/index.html.erb
+++ b/ruby/rails7-sidekiq/app/app/views/examples/index.html.erb
@@ -1,6 +1,8 @@
 <h1>Tests in this example app</h1>
 
 <ul>
+  <li><%= link_to "Slow request", slow_path %></li>
+  <li><%= link_to "Request with error", error_path %></li>
   <li><%= link_to "Sidekiq workers", workers_path %></li>
   <li><%= link_to "Redis queries", redis_path %></li>
   <li><%= link_to "Excon requests", requests_path %></li>

--- a/ruby/rails7-sidekiq/app/app/views/layouts/application.html.erb
+++ b/ruby/rails7-sidekiq/app/app/views/layouts/application.html.erb
@@ -11,6 +11,10 @@
   </head>
 
   <body>
+    <% flash.each do |key, value| %>
+      <div class="alert alert-<%= key %>"><%= value %></div>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/ruby/rails7-sidekiq/app/app/workers/active_job_error_worker.rb
+++ b/ruby/rails7-sidekiq/app/app/workers/active_job_error_worker.rb
@@ -3,6 +3,9 @@ class ActiveJobErrorWorker < ActiveJob::Base
   sidekiq_options :retry => 3
 
   def perform(argument = nil, options = {})
+    Rails.error.handle do
+      1 + '1' # raises TypeError
+    end
     raise "Error #{argument}"
   end
 end

--- a/ruby/rails7-sidekiq/app/config/application.rb
+++ b/ruby/rails7-sidekiq/app/config/application.rb
@@ -20,5 +20,7 @@ module TestApp
     config.hosts << "app"
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/ruby/rails7-sidekiq/app/config/routes.rb
+++ b/ruby/rails7-sidekiq/app/config/routes.rb
@@ -36,4 +36,5 @@ Rails.application.routes.draw do
   root :to => "examples#index"
   get "/slow", to: "examples#slow"
   get "/error", to: "examples#error"
+  get "/error_reporter", to: "examples#error_reporter"
 end


### PR DESCRIPTION
## Add links to Sidekiq app example paths

Allow for easier testing, rather than guessing the route.

## Add test for Rails error reporter

Report an error that is not reraised by Rails's error handler.

## Add Rails error handler errors to Active Job jobs

Report an extra error in the Active Job jobs.

## Show flash messages in Rails Sidekiq test app

Show messages that are set by controller before redirects and such.

---

Tracking issue: https://github.com/appsignal/appsignal-ruby/issues/779