### PR TITLE
Fix broken test setups

### DIFF
--- a/nodejs/v3/express-apollo/Dockerfile
+++ b/nodejs/v3/express-apollo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/express-apollo/commands/run
+++ b/nodejs/v3/express-apollo/commands/run
@@ -8,6 +8,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/nodejs/v3/express-mongoose/Dockerfile
+++ b/nodejs/v3/express-mongoose/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/express-mongoose/commands/run
+++ b/nodejs/v3/express-mongoose/commands/run
@@ -16,6 +16,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/nodejs/v3/express-postgres/Dockerfile
+++ b/nodejs/v3/express-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/express-redis-alpine/Dockerfile
+++ b/nodejs/v3/express-redis-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:18-alpine
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2022-01-25

--- a/nodejs/v3/express-redis/Dockerfile
+++ b/nodejs/v3/express-redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/express-yoga/Dockerfile
+++ b/nodejs/v3/express-yoga/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/express-yoga/commands/run
+++ b/nodejs/v3/express-yoga/commands/run
@@ -8,6 +8,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/nodejs/v3/fastify/Dockerfile
+++ b/nodejs/v3/fastify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/fastify/commands/run
+++ b/nodejs/v3/fastify/commands/run
@@ -8,6 +8,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/nodejs/v3/koa-mongo/Dockerfile
+++ b/nodejs/v3/koa-mongo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/koa-mongo/commands/run
+++ b/nodejs/v3/koa-mongo/commands/run
@@ -16,6 +16,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/nodejs/v3/koa-mysql/Dockerfile
+++ b/nodejs/v3/koa-mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/koa-mysql/commands/run
+++ b/nodejs/v3/koa-mysql/commands/run
@@ -8,6 +8,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/nodejs/v3/nestjs-prisma/Dockerfile
+++ b/nodejs/v3/nestjs-prisma/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/nestjs-prisma/commands/run
+++ b/nodejs/v3/nestjs-prisma/commands/run
@@ -8,6 +8,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/nodejs/v3/nestjs/Dockerfile
+++ b/nodejs/v3/nestjs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/nextjs/Dockerfile
+++ b/nodejs/v3/nextjs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/restify/Dockerfile
+++ b/nodejs/v3/restify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-buster
+FROM node:18-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/restify/Dockerfile
+++ b/nodejs/v3/restify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-buster
+FROM node:16-buster
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-03-28

--- a/nodejs/v3/restify/commands/run
+++ b/nodejs/v3/restify/commands/run
@@ -8,6 +8,7 @@ npm install -g npm@7.18.1
 echo "Install, link and build integration"
 (
 cd /integration
+git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
 git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup

--- a/ruby/jruby-rails6/Dockerfile
+++ b/ruby/jruby-rails6/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.3.3
+FROM jruby:9.4.2.0
 
 # Update this if the Docker image changes
 ENV REFRESHED_AT=2022-02-24

--- a/ruby/jruby-rails6/app/Gemfile
+++ b/ruby/jruby-rails6/app/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.8'
+ruby '3.1.0'
 
 gem 'appsignal', :path => '/integration'
 

--- a/ruby/jruby-rails6/commands/run
+++ b/ruby/jruby-rails6/commands/run
@@ -5,6 +5,7 @@ set -eu
 echo "Install AppSignal Ruby extension"
 (
   cd /integration
+  git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
   RUBY_ENGINE=jruby jruby -S rake extension:install
 )
 

--- a/ruby/rails6-mysql/Dockerfile
+++ b/ruby/rails6-mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.1
+FROM ruby:3.2.2
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-02-04

--- a/ruby/rails6-mysql/app/Gemfile
+++ b/ruby/rails6-mysql/app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.1'
+ruby '3.2.2'
 
 gem "appsignal", :path => "/integration"
 

--- a/ruby/rails6-postgres/Dockerfile
+++ b/ruby/rails6-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.4
+FROM ruby:3.2.2
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-02-04

--- a/ruby/rails6-sequel/Dockerfile
+++ b/ruby/rails6-sequel/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.3
+FROM ruby:3.2.2
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2022-01-06

--- a/ruby/rails6-sequel/app/Gemfile
+++ b/ruby/rails6-sequel/app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.3'
+ruby '3.2.2'
 
 gem 'rails', '~> 6.1.4', '>= 6.1.4.4'
 gem 'pg'

--- a/ruby/rails6-shoryuken/Dockerfile
+++ b/ruby/rails6-shoryuken/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.1
+FROM ruby:3.2.2
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-03-01

--- a/ruby/rails6-shoryuken/app/Gemfile
+++ b/ruby/rails6-shoryuken/app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.1'
+ruby '3.2.2'
 
 gem "appsignal", :path => "/integration"
 gem "shoryuken", "~> 5.3.2"

--- a/ruby/rails6-sidekiq/Dockerfile
+++ b/ruby/rails6-sidekiq/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.2
+FROM ruby:3.2.2
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-02-10


### PR DESCRIPTION
[Update all Ruby versions](https://github.com/appsignal/test-setups/commit/c3037273f31576b658778be5ee8063b28d803054) 

The latest AppSignal gem version drops support for EoL Ruby versions.
This commits updates all apps to use the latest Ruby version available.

[Update apps using Node.js 17](https://github.com/appsignal/test-setups/commit/1e31e28cd43d2587756aeafa54af9e7fb5a238ca) 

We had a bunch of apps using an EoL Node.js version. This made them
broke due to some dependencies dropping support for it. Now all v3
applications work with Node.js v18.

[Fix JRuby app](https://github.com/appsignal/test-setups/commit/ecabd00b2a854e594d8e366a2a6123414c5082f3) 

Building the integration from the submodule caused git to fail due to
dubious ownership on the repository. This commit adds the submodule as
an exception.

[Set Node version for Restify](https://github.com/appsignal/test-setups/commit/7c34358ac73916906081f000d4e9f071288fff5f) 

Restify has some incompatibilities with Node v18. Let's set its setup
to Nove v16 until fixed.