### PR TITLE
Use __appsignal__.py file for config

### DIFF
--- a/python/django4-celery/app/__appsignal__.py
+++ b/python/django4-celery/app/__appsignal__.py
@@ -4,5 +4,4 @@ appsignal = Appsignal(
     active=True,
     name="python/django4-celery",
     environment="development",
-    log_level="trace",
 )

--- a/python/django4-celery/app/manage.py
+++ b/python/django4-celery/app/manage.py
@@ -5,7 +5,7 @@ import sys
 import requests
 import redis
 
-from appsignal_config import appsignal
+from __appsignal__ import appsignal
 
 def main():
     """Run administrative tasks."""

--- a/python/django4-celery/app/tasks.py
+++ b/python/django4-celery/app/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from appsignal_config import appsignal
+from __appsignal__ import appsignal
 
 from opentelemetry import trace
 


### PR DESCRIPTION
Make the test setup for Django follow the same structure that results from following the AppSignal for Python installer.

This is a leftover from [the Python installer task](https://github.com/appsignal/appsignal-python/pull/38) that I forgot to commit and push. 🤦