### PR TITLE
Add Python flask test-setup

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -169,3 +169,6 @@ blocks:
         - name: python/django4-celery
           commands:
             - "rake app=python/django4-celery app:test"
+        - name: python/flask
+          commands:
+            - "rake app=python/flask app:test"

--- a/python/flask/Dockerfile
+++ b/python/flask/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-buster
+
+# Update this if the docker image changes
+ENV REFRESHED_AT=2023-05-23
+
+# Copy commands into the container
+RUN mkdir /commands
+COPY ./commands/* /commands/
+RUN chmod +x /commands/*
+
+# Run the app
+CMD /commands/run

--- a/python/flask/app/.gitignore
+++ b/python/flask/app/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+tmp/

--- a/python/flask/app/__appsignal__.py
+++ b/python/flask/app/__appsignal__.py
@@ -1,0 +1,7 @@
+from appsignal import Appsignal
+
+appsignal = Appsignal(
+    active=True,
+    name="python/flask",
+    environment="development",
+)

--- a/python/flask/app/app.py
+++ b/python/flask/app/app.py
@@ -1,0 +1,21 @@
+# Important to import and start appsignal before any other imports
+# otherwise the automatic instrumentation won't work
+from __appsignal__ import appsignal
+appsignal.start()
+
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/")
+def hello_world():
+    return "<p>Hello, World!</p>"
+
+@app.route("/slow")
+def slow():
+    import time
+    time.sleep(2)
+    return "<p>Wow, that took forever</p>"
+
+@app.route("/error")
+def error():
+    raise Exception("I am an error!")

--- a/python/flask/app/processmon.toml
+++ b/python/flask/app/processmon.toml
@@ -1,0 +1,11 @@
+[[paths_to_watch]]
+path = "/app"
+
+[processes.flask]
+command = "flask"
+args = [
+  "run",
+  "--host=0.0.0.0",
+  "--port=4001",
+]
+working_dir = "/app"

--- a/python/flask/app/requirements.txt
+++ b/python/flask/app/requirements.txt
@@ -1,0 +1,2 @@
+flask
+opentelemetry-instrumentation-flask

--- a/python/flask/commands/run
+++ b/python/flask/commands/run
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+pip3 install --upgrade pip
+
+cd /integration
+
+pip3 install hatch
+hatch clean
+hatch run build:me
+
+cd /app
+
+echo "Installing dependencies"
+pip3 install -r requirements.txt
+pip3 install /integration/dist/* --force-reinstall
+
+echo "Starting app"
+#/commands/processmon processmon.toml
+flask run --host=0.0.0.0 --port=4001

--- a/python/flask/docker-compose.yml
+++ b/python/flask/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    image: python/flask
+    ports:
+      - "4001:4001"
+    env_file:
+      - ../../appsignal_key.env
+    environment:
+      - PORT=4001
+    volumes:
+      - ./app:/app
+      - ../integration:/integration
+  tests:
+    build: ../../support/server-tests
+    image: server-tests
+    profiles:
+      - tests
+    depends_on:
+      - app
+    environment:
+      - APP_NAME=python/flask
+      - APP_URL=http://app:4001


### PR DESCRIPTION
Flask application with the three basic endpoints provided by other apps. It doesn't include any additional dependencies such as data storages or background job managers, but can be used as a base to add those to new apps.

Part of: https://github.com/appsignal/appsignal-python/issues/9