### PR TITLE
Add ASGI (FastAPI, Starlette) test setups

### DIFF
--- a/python/fastapi/Dockerfile
+++ b/python/fastapi/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-buster
+
+# Update this if the docker image changes
+ENV REFRESHED_AT=2023-05-23
+
+# Copy commands into the container
+RUN mkdir /commands
+COPY ./commands/* /commands/
+RUN chmod +x /commands/*
+
+# Run the app
+CMD /commands/run

--- a/python/fastapi/app/.gitignore
+++ b/python/fastapi/app/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+tmp/

--- a/python/fastapi/app/__appsignal__.py
+++ b/python/fastapi/app/__appsignal__.py
@@ -1,0 +1,8 @@
+from appsignal import Appsignal
+
+appsignal = Appsignal(
+    active=True,
+    name="python/fastapi",
+    environment="development",
+    log_level="trace",
+)

--- a/python/fastapi/app/main.py
+++ b/python/fastapi/app/main.py
@@ -1,0 +1,37 @@
+from __appsignal__ import appsignal
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+appsignal.start()
+
+app = FastAPI()
+
+@app.get("/", response_class=HTMLResponse)
+async def root():
+    return """
+      <h1>Python FastAPI OpenTelemetry app</h1>
+
+      <ul>
+        <li><a href="/slow">/slow: Trigger a slow request</a></li>
+        <li><a href="/error">/error: Trigger an error</a></li>
+        <li><a href="/hello/world">/hello/{name}: Use parameterised routing</a></li>
+      </ul>
+    """
+
+@app.get("/slow")
+async def slow():
+    import time
+    time.sleep(2)
+    return {"wow_that_took": "forever"}
+
+@app.get("/error")
+async def error():
+    raise Exception("I am an error!")
+
+@app.get("/hello/{name}")
+async def hello(name):
+    return {"greeting": f"Hello, {name}!"}
+
+
+FastAPIInstrumentor.instrument_app(app)

--- a/python/fastapi/app/processmon.toml
+++ b/python/fastapi/app/processmon.toml
@@ -1,0 +1,12 @@
+[[paths_to_watch]]
+path = "/app"
+ignore = ["__pycache__"]
+
+[processes.fastapi]
+command = "uvicorn"
+args = [
+  "main:app",
+  "--host=0.0.0.0",
+  "--port=4001",
+]
+working_dir = "/app"

--- a/python/fastapi/app/requirements.txt
+++ b/python/fastapi/app/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+opentelemetry-instrumentation-fastapi

--- a/python/fastapi/commands/run
+++ b/python/fastapi/commands/run
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+pip3 install --upgrade pip
+
+cd /integration
+
+pip3 install hatch
+hatch clean
+hatch run build:me
+
+cd /app
+
+echo "Installing dependencies"
+pip3 install -r requirements.txt
+pip3 install /integration/dist/* --force-reinstall
+
+echo "Starting app"
+/commands/processmon processmon.toml

--- a/python/fastapi/docker-compose.yml
+++ b/python/fastapi/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    image: python/fastapi
+    ports:
+      - "4001:4001"
+    env_file:
+      - ../../appsignal.env
+      - ../../appsignal_key.env
+    environment:
+      - PORT=4001
+    volumes:
+      - ./app:/app
+      - ../integration:/integration
+  tests:
+    build: ../../support/server-tests
+    image: server-tests
+    profiles:
+      - tests
+    depends_on:
+      - app
+    environment:
+      - APP_NAME=python/fastapi
+      - APP_URL=http://app:4001

--- a/python/flask/app/app.py
+++ b/python/flask/app/app.py
@@ -14,6 +14,7 @@ def home():
       <ul>
         <li><a href="/slow">/slow: Trigger a slow request</a></li>
         <li><a href="/error">/error: Trigger an error</a></li>
+        <li><a href="/hello/world">/hello/&lt;name&gt;: Use parameterised routing</a></li>
       </ul>
     """
 
@@ -26,3 +27,7 @@ def slow():
 @app.route("/error")
 def error():
     raise Exception("I am an error!")
+
+@app.route("/hello/<name>")
+def hello(name):
+    return f"<p>Hello, {name}!"

--- a/python/starlette/Dockerfile
+++ b/python/starlette/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-buster
+
+# Update this if the docker image changes
+ENV REFRESHED_AT=2023-05-23
+
+# Copy commands into the container
+RUN mkdir /commands
+COPY ./commands/* /commands/
+RUN chmod +x /commands/*
+
+# Run the app
+CMD /commands/run

--- a/python/starlette/app/.gitignore
+++ b/python/starlette/app/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+tmp/

--- a/python/starlette/app/__appsignal__.py
+++ b/python/starlette/app/__appsignal__.py
@@ -1,0 +1,8 @@
+from appsignal import Appsignal
+
+appsignal = Appsignal(
+    active=True,
+    name="python/starlette",
+    environment="development",
+    log_level="trace",
+)

--- a/python/starlette/app/main.py
+++ b/python/starlette/app/main.py
@@ -1,0 +1,39 @@
+from __appsignal__ import appsignal
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse, JSONResponse
+from starlette.routing import Route
+
+from opentelemetry.instrumentation.starlette import StarletteInstrumentor
+
+appsignal.start()
+
+async def root(request):
+    return HTMLResponse("""
+      <h1>Python Starlette OpenTelemetry app</h1>
+
+      <ul>
+        <li><a href="/slow">/slow: Trigger a slow request</a></li>
+        <li><a href="/error">/error: Trigger an error</a></li>
+        <li><a href="/hello/world">/hello/{name}: Use parameterised routing</a></li>
+      </ul>
+    """)
+
+async def slow(request):
+    import time
+    time.sleep(2)
+    return JSONResponse({"wow_that_took": "forever"})
+
+async def error(request):
+    raise Exception("I am an error!")
+
+async def hello(request):
+    return JSONResponse({"greeting": f"Hello, {request.path_params['name']}!"})
+
+app = Starlette(routes=[
+    Route('/', root),
+    Route('/slow', slow),
+    Route('/error', error),
+    Route('/hello/{name}', hello),
+])
+
+StarletteInstrumentor.instrument_app(app)

--- a/python/starlette/app/processmon.toml
+++ b/python/starlette/app/processmon.toml
@@ -1,0 +1,12 @@
+[[paths_to_watch]]
+path = "/app"
+ignore = ["__pycache__"]
+
+[processes.starlette]
+command = "uvicorn"
+args = [
+  "main:app",
+  "--host=0.0.0.0",
+  "--port=4001",
+]
+working_dir = "/app"

--- a/python/starlette/app/requirements.txt
+++ b/python/starlette/app/requirements.txt
@@ -1,0 +1,3 @@
+starlette
+uvicorn
+opentelemetry-instrumentation-starlette

--- a/python/starlette/commands/run
+++ b/python/starlette/commands/run
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+pip3 install --upgrade pip
+
+cd /integration
+
+pip3 install hatch
+hatch clean
+hatch run build:me
+
+cd /app
+
+echo "Installing dependencies"
+pip3 install -r requirements.txt
+pip3 install /integration/dist/* --force-reinstall
+
+echo "Starting app"
+/commands/processmon processmon.toml

--- a/python/starlette/docker-compose.yml
+++ b/python/starlette/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    image: python/starlette
+    ports:
+      - "4001:4001"
+    env_file:
+      - ../../appsignal.env
+      - ../../appsignal_key.env
+    environment:
+      - PORT=4001
+    volumes:
+      - ./app:/app
+      - ../integration:/integration
+  tests:
+    build: ../../support/server-tests
+    image: server-tests
+    profiles:
+      - tests
+    depends_on:
+      - app
+    environment:
+      - APP_NAME=python/starlette
+      - APP_URL=http://app:4001


### PR DESCRIPTION
### [Add Flask parameterised routing endpoint](https://github.com/appsignal/test-setups/commit/f0f4f41515164c663630582a9e1c4896dd4d0dec)

Add an endpoint that has a parameterised route, in order to check
that the route parameter is replaced with its placeholder correctly.

### [Add FastAPI test setup](https://github.com/appsignal/test-setups/commit/716b80538ef815389ae2433cabc90a1dd3cb2620)

Made by following the FastAPI "Getting Started" documentation page
and copy-pasting from the Flask test setup. Uses Uvicorn as the
server since that is what the FastAPI documentation page recommends.

### [Add Starlette test setup](https://github.com/appsignal/test-setups/commit/4b852ec097673774027660c86e860b11e72afb34)

A very straight-forward copy-paste and re-arranging of the FastAPI
test setup.