### PR TITLE
Update Sidekiq 7 test app

### DIFF
--- a/ruby/rails7-sidekiq/app/Gemfile.lock
+++ b/ruby/rails7-sidekiq/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /integration
   specs:
-    appsignal (3.4.1)
+    appsignal (3.4.4)
       rack
 
 GEM
@@ -87,8 +87,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.1.10)
-    connection_pool (2.3.0)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.1)
@@ -139,7 +139,7 @@ GEM
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.5)
+    rack (2.2.7)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4.3)
@@ -169,7 +169,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    redis-client (0.12.1)
+    redis-client (0.14.1)
       connection_pool
     regexp_parser (2.6.1)
     reline (0.3.2)
@@ -180,11 +180,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.0.3)
+    sidekiq (7.1.2)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
-      redis-client (>= 0.11.0)
+      redis-client (>= 0.14.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)


### PR DESCRIPTION
- Update Sidekiq to the latest version.
- Remove `.delay` methods of queuing jobs, they were removed in Sidekiq 7.
- Update Sidekiq internal error example to use RedisClient, the Redis gem Sidekiq switched to.