### PR TITLE
Remove deprecated debug option from apps

### DIFF
--- a/elixir/single-task/app/config/appsignal.exs
+++ b/elixir/single-task/app/config/appsignal.exs
@@ -4,5 +4,4 @@ config :appsignal, :config,
   active: true,
   otp_app: :single_task,
   env: Mix.env,
-  debug: true,
   transaction_debug_mode: true

--- a/ruby/linux-arm/app/config/appsignal.yml
+++ b/ruby/linux-arm/app/config/appsignal.yml
@@ -1,5 +1,4 @@
 default: &defaults
-  debug: true
 
 test:
   <<: *defaults

--- a/ruby/padrino/app/config/appsignal.yml
+++ b/ruby/padrino/app/config/appsignal.yml
@@ -1,6 +1,5 @@
 default: &defaults
   push_api_key: "<%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
-  debug: true
 
 development:
   <<: *defaults

--- a/ruby/shoryuken/app/config/appsignal.yml
+++ b/ruby/shoryuken/app/config/appsignal.yml
@@ -1,7 +1,6 @@
 default: &defaults
   push_api_key: "<%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
   name: "Shoryuken example app"
-  debug: true
 
 development:
   <<: *defaults

--- a/ruby/sinatra-gvltools/app/config/appsignal.yml
+++ b/ruby/sinatra-gvltools/app/config/appsignal.yml
@@ -1,5 +1,4 @@
 default: &defaults
-  debug: true
 
 test:
   <<: *defaults

--- a/ruby/sinatra-puma/app/config/appsignal.yml
+++ b/ruby/sinatra-puma/app/config/appsignal.yml
@@ -1,5 +1,4 @@
 default: &defaults
-  debug: true
 
 test:
   <<: *defaults

--- a/ruby/sinatra/app/config/appsignal.yml
+++ b/ruby/sinatra/app/config/appsignal.yml
@@ -1,5 +1,4 @@
 default: &defaults
-  debug: true
 
 test:
   <<: *defaults


### PR DESCRIPTION
Remove the debug option to remove the warning about using deprecated config options. We already configure `APPSIGNAL_LOG_LEVEL=trace` in the `appsignal.env` file.