### PR TITLE
Create log file before tailing it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -200,6 +200,7 @@ namespace :app do
     desc "Tail appsignal.log"
     task :appsignal do
       @app = get_app
+      run_command "cd #{@app} && docker-compose exec app touch /tmp/appsignal.log"
       run_command "cd #{@app} && docker-compose exec app tail -f /tmp/appsignal.log"
     end
   end


### PR DESCRIPTION
If the log file doesn't exist yet, I don't want to have to keep retrying the command until it does. This extra `touch` makes sure the file exists and we can tail it.

I tried to combine the commands into one `docker-compose exec`, but then you need to specify the shell the container uses, which we don't know from the outside.
I tried to rely on the `APPSIGNAL_LOG_PATH=/tmp` env var set in `appsignal.env`, but had the same problem.