### PR TITLE
Add custom instrumentation Plug endpoint

### DIFF
--- a/elixir/plug/app/lib/plug_example.ex
+++ b/elixir/plug/app/lib/plug_example.ex
@@ -18,4 +18,11 @@ defmodule PlugExample do
   get "/error" do
     raise "Whoops!"
   end
+
+  get "/custom" do
+    Appsignal.Tracer.root_span()
+    |> Appsignal.Span.set_sample_data("params", %{"wow_such_custom" => "amaze"})
+
+    send_resp(conn, 200, "Reported custom sample data")
+  end
 end


### PR DESCRIPTION
Add an endpoint that uses custom instrumentation to set params -- these params should not be overriden with appsignal/appsignal-elixir-plug#37.