### PR TITLE
Log to both STDOUT and AppSignal in Sidekiq app

### DIFF
--- a/ruby/rails7-sidekiq/app/Gemfile.lock
+++ b/ruby/rails7-sidekiq/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /integration
   specs:
-    appsignal (3.4.4)
+    appsignal (3.4.5)
       rack
 
 GEM

--- a/ruby/rails7-sidekiq/app/config/environment.rb
+++ b/ruby/rails7-sidekiq/app/config/environment.rb
@@ -1,7 +1,5 @@
 # Load the Rails application.
 require_relative "application"
 
-Rails.logger = ActiveSupport::TaggedLogging.new(Appsignal::Logger.new("rails"))
-
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/ruby/rails7-sidekiq/app/config/initializers/logging.rb
+++ b/ruby/rails7-sidekiq/app/config/initializers/logging.rb
@@ -1,0 +1,3 @@
+console_logger = ActiveSupport::Logger.new(STDOUT)
+Rails.application.config.log_tags = [:request_id]
+Rails.logger = console_logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::TaggedLogging.new(Appsignal::Logger.new("rails"))))

--- a/ruby/rails7-sidekiq/app/config/initializers/sidekiq.rb
+++ b/ruby/rails7-sidekiq/app/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
 Sidekiq.configure_server do |config|
-  config.logger = Appsignal::Logger.new("sidekiq")
+  console_logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = console_logger.extend(ActiveSupport::Logger.broadcast(Appsignal::Logger.new("sidekiq")))
   config.logger.formatter = Sidekiq::Logger::Formatters::WithoutTimestamp.new
 end


### PR DESCRIPTION
Make development/testing easier by logging to both the terminal/STDOUT and AppSignal (what we also want to test if it works). Without this change it would only log to AppSignal, which is delayed and not part of a local dev workflow.

Use ActiveSupport::Logger.broadcast to wrap loggers and send logs to multiple backends.

Move the Rails logger config from `config/environment.rb` to an initializer as documented in https://github.com/appsignal/appsignal-docs/pull/1453.
