### PR TITLE
Standardize app ports for Elixir apps

### DIFF
--- a/elixir/alpine-release/app/config/dev.exs
+++ b/elixir/alpine-release/app/config/dev.exs
@@ -15,8 +15,9 @@ config :demo, Demo.Repo,
 # The watchers configuration can be used to run external
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
+port = String.to_integer(System.get_env("PORT") || "4000")
 config :demo, DemoWeb.Endpoint,
-  http: [port: 4000],
+  http: [port: port],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/elixir/alpine-release/docker-compose.yml
+++ b/elixir/alpine-release/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     depends_on:
       - postgres
     ports:
-      - "4001:4000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=elixir-alpine-release
     env_file:
       - postgres.env
@@ -30,4 +31,4 @@ services:
       - app
     environment:
       - APP_NAME=elixir/alpine-release
-      - APP_URL=http://app:4000
+      - APP_URL=http://app:4001

--- a/elixir/phoenix-example/app/config/dev.exs
+++ b/elixir/phoenix-example/app/config/dev.exs
@@ -17,10 +17,11 @@ config :appsignal_phoenix_example, AppsignalPhoenixExample.Repo,
 # The watchers configuration can be used to run external
 # watchers to your application. For example, we use it
 # with esbuild to bundle .js and .css sources.
+port = String.to_integer(System.get_env("PORT") || "4000")
 config :appsignal_phoenix_example, AppsignalPhoenixExampleWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {0, 0, 0, 0}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: port],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/elixir/phoenix-example/docker-compose.yml
+++ b/elixir/phoenix-example/docker-compose.yml
@@ -13,8 +13,9 @@ services:
     depends_on:
       - postgres
     ports:
-      - "4001:4000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=elixir-phoenix-example
       - INTEGRATION_PATH=/integration
     env_file:
@@ -33,4 +34,4 @@ services:
       - app
     environment:
       - APP_NAME=elixir/phoenix-example
-      - APP_URL=http://app:4000
+      - APP_URL=http://app:4001

--- a/elixir/plug-oban/app/lib/application.ex
+++ b/elixir/plug-oban/app/lib/application.ex
@@ -4,10 +4,11 @@ defmodule PlugOban.Application do
   require Logger
 
   def start(_type, _args) do
+    port = String.to_integer(System.get_env("PORT") || "4000")
     children = [
       PlugOban.Repo,
       {Oban, Application.fetch_env!(:plug_oban, Oban)},
-      {Plug.Cowboy, scheme: :http, plug: PlugOban.Router, options: [port: 4000]}
+      {Plug.Cowboy, scheme: :http, plug: PlugOban.Router, options: [port: port]}
     ]
 
     Logger.info("Listening on http://localhost:4001")

--- a/elixir/plug-oban/docker-compose.yml
+++ b/elixir/plug-oban/docker-compose.yml
@@ -13,8 +13,9 @@ services:
     depends_on:
       - postgres
     ports:
-      - "4001:4000"
+      - "4001:4001"
     environment:
+      - PORT=4001
       - APPSIGNAL_APP_NAME=elixir-plug-oban
       - INTEGRATION_PATH=/integration
     env_file:
@@ -33,4 +34,4 @@ services:
       - app
     environment:
       - APP_NAME=elixir/plug-oban
-      - APP_URL=http://app:4000
+      - APP_URL=http://app:4001

--- a/elixir/plug/app/lib/plug_example/application.ex
+++ b/elixir/plug/app/lib/plug_example/application.ex
@@ -7,8 +7,9 @@ defmodule PlugExample.Application do
 
   @impl true
   def start(_type, _args) do
+    port = String.to_integer(System.get_env("PORT") || "4000")
     children = [
-      {Plug.Cowboy, scheme: :http, plug: PlugExample, options: [port: 4001]}
+      {Plug.Cowboy, scheme: :http, plug: PlugExample, options: [port: port]}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
Standardize all Elixir app ports to 4001, using the PORT env var, so it's the same how all apps listen to the same port on container host and when connected with a shell to the container.

Other apps are also (mostly) set up this way (we'll fix other ones later).