### PR TITLE
Add example route to Next.js app with client fetch

### DIFF
--- a/nodejs/v3/nextjs-noappdir/README.md
+++ b/nodejs/v3/nextjs-noappdir/README.md
@@ -4,6 +4,10 @@ For front-end error reporting to work, add a `appsignal_key.env` file (example
 can be found in `appsignal_key.env.example`), and add the front-end API key for
 the specific existing app you want to add the front-end errors to.
 
+## Client-side dynamic route fetching data in the client
+
+Make a request to [/stargazers/vercel/next.js](http://localhost:4001/stargazers/vercel/next.js) to test how a route using client side data fetching reports its data. This is different from using [getServerSideProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props), because it doesn't hit the Next.js server.
+
 ## Production mode
 
 This app starts by default in development mode.

--- a/nodejs/v3/nextjs-noappdir/app/src/pages/stargazers/[org]/[repo].tsx
+++ b/nodejs/v3/nextjs-noappdir/app/src/pages/stargazers/[org]/[repo].tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Profile() {
+  const router = useRouter()
+  const [data, setData] = useState(null)
+  const [isLoading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch(`https://api.github.com/repos/${router.query.org}/${router.query.repo}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setData(data)
+        setLoading(false)
+      })
+  })
+
+  if (isLoading) return <p>Loading...</p>
+  if (!data) return <p>No repo data</p>
+
+  return (
+    <div>
+      <h1>Stargazers on {data["full_name"]}: {data["stargazers_count"]}</h1>
+    </div>
+  )
+}


### PR DESCRIPTION
Test how Next.js requests are reported from components using client side fetching. They don't include the `next.route` attribute.


[skip review]