### PR TITLE
Update Node.js install method

### DIFF
--- a/elixir/phoenix-example/Dockerfile
+++ b/elixir/phoenix-example/Dockerfile
@@ -2,10 +2,15 @@ FROM elixir:1.14.1
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2022-10-27
+ENV NODE_MAJOR=18
 
-# Install node 12
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get -y install nodejs
+RUN apt-get update && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get -y install nodejs
 
 # Copy commands into the container
 RUN mkdir /commands

--- a/ruby/jruby-rails6/Dockerfile
+++ b/ruby/jruby-rails6/Dockerfile
@@ -2,9 +2,14 @@ FROM jruby:9.4.2.0
 
 # Update this if the Docker image changes
 ENV REFRESHED_AT=2022-02-24
+ENV NODE_MAJOR=18
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
   apt-get install -y nodejs python2 git && \
   npm install -g npm yarn
 

--- a/ruby/rails6-mongo/Dockerfile
+++ b/ruby/rails6-mongo/Dockerfile
@@ -2,9 +2,14 @@ FROM ruby:3.0.3
 
 # Update this if the Docker image changes
 ENV REFRESHED_AT=2022-02-01
+ENV NODE_MAJOR=18
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
   apt-get install -y nodejs python2 && \
   npm install -g npm yarn
 

--- a/ruby/rails6-mysql/Dockerfile
+++ b/ruby/rails6-mysql/Dockerfile
@@ -2,9 +2,14 @@ FROM ruby:3.2.2-bullseye
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2021-02-04
+ENV NODE_MAJOR=18
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
   apt-get install -y nodejs python2 && \
   npm install -g npm yarn
 

--- a/ruby/rails6-sequel/Dockerfile
+++ b/ruby/rails6-sequel/Dockerfile
@@ -1,11 +1,16 @@
 FROM ruby:3.2.2-bullseye
 
-# Update this if the docker image changes
-ENV REFRESHED_AT=2022-01-06
+# Update this if the Docker image changes
+ENV REFRESHED_AT=2022-11-07
+ENV NODE_MAJOR=18
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-  apt-get install -y nodejs python2 postgresql-client && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install -y nodejs python3 && \
   npm install -g npm yarn
 
 RUN gem update --system && gem install bundler

--- a/ruby/rails6-shakapacker/Dockerfile
+++ b/ruby/rails6-shakapacker/Dockerfile
@@ -5,9 +5,14 @@ ENV REFRESHED_AT=2023-06-23
 
 ARG TESTING
 ENV TESTING=$TESTING
+ENV NODE_MAJOR=18
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
   apt-get install -y nodejs python2 && \
   npm install -g npm yarn
 

--- a/ruby/rails7-delayed-job/Dockerfile
+++ b/ruby/rails7-delayed-job/Dockerfile
@@ -2,9 +2,14 @@ FROM ruby:3.1.3
 
 # Update this if the Docker image changes
 ENV REFRESHED_AT=2022-11-07
+ENV NODE_MAJOR=18
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
   apt-get install -y nodejs python3 && \
   npm install -g npm yarn
 

--- a/ruby/rails7-sidekiq/Dockerfile
+++ b/ruby/rails7-sidekiq/Dockerfile
@@ -2,9 +2,14 @@ FROM ruby:3.1.2
 
 # Update this if the Docker image changes
 ENV REFRESHED_AT=2022-11-07
+ENV NODE_MAJOR=18
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
   apt-get install -y nodejs python3 && \
   npm install -g npm yarn
 


### PR DESCRIPTION
The Node.js 18 installer had a deprecation warning of 60 seconds from nodesource telling us this method is deprecated. Using the install method described at:
https://github.com/nodesource/distributions

Speed up the build by removing that dumb 60 second sleep.

[skip review]