### PR TITLE
Use metrics helpers in Flask

### DIFF
--- a/python/flask/app/app.py
+++ b/python/flask/app/app.py
@@ -9,44 +9,14 @@ from appsignal import (
     set_tag,
     set_root_name,
     send_error,
+    set_gauge,
+    increment_counter,
 )
 
 from flask import Flask, request
 app = Flask(__name__)
 
-from typing import Iterable
-from opentelemetry import metrics
-from opentelemetry.metrics import Observation, CallbackOptions
-
 from random import randrange
-
-meter = metrics.get_meter("flask-app-custom-metrics")
-
-monotonic_counter_with_tags = meter.create_counter(
-    "monotonic_counter_with_tags",
-    unit="1",
-    description="monotonic counter with tags"
-)
-monotonic_counter = meter.create_counter(
-    "monotonic_counter", unit="1", description="monotonic counter"
-)
-non_monotonic_counter = meter.create_up_down_counter(
-    "non_monotonic_counter",
-    unit="1",
-    description="non monotonic counter"
-)
-
-
-def gauge_callback(options: CallbackOptions) -> Iterable[Observation]:
-    return [Observation(100 + randrange(50))]
-
-
-meter.create_observable_gauge(
-    "some_gauge",
-    callbacks=[gauge_callback],
-    unit="1",
-    description="test gauge"
-)
 
 @app.route("/")
 def home():
@@ -89,10 +59,12 @@ def hello(name):
 
 @app.route("/metrics")
 def metrics():
-    monotonic_counter_with_tags.add(1, {"tag1": "value1", "tag2": "value2"})
-    monotonic_counter.add(1)
-    non_monotonic_counter.add(10)
-    non_monotonic_counter.add(-5)
+    increment_counter("some_counter", 1)
+    increment_counter("some_negative_counter", -1)
+    increment_counter("some_counter_with_tags", 1, {"tag1": "value1", "tag2": "value2"})
+    set_gauge("some_gauge", randrange(1, 100))
+    set_gauge("some_gauge_with_tags", randrange(1, 100), {"tag1": "value1", "tag2": "value2"})
+
     return "<p>Emitted some custom metrics!</p>"
 
 @app.route("/custom", methods=["GET", "POST"])


### PR DESCRIPTION
This PR builds on top of the changes in #149. @tombruijn feel free to force-push anything you see fit :)

---

[Use metrics helpers in Flask](https://github.com/appsignal/test-setups/commit/728259a3cb7ff63264969ba11bbef0a967780cbb)

Instead of creating OpenTelemetry metrics manually, use the metrics
helpers implemented in https://github.com/appsignal/appsignal-python/pull/127.

This imports them from the root of the package, as implemented in
https://github.com/appsignal/appsignal-python/pull/132.