### PR TITLE
Do not use Flask 3 yet

### DIFF
--- a/python/flask/app/requirements.txt
+++ b/python/flask/app/requirements.txt
@@ -1,2 +1,2 @@
-flask
+flask<3
 opentelemetry-instrumentation-flask


### PR DESCRIPTION
By default, pip will install the latest version, which is not supported by the OpenTelemetry integration yet.