### PR TITLE
Use Rails 7.1+ broadcast logger

### DIFF
--- a/ruby/rails7-sidekiq/app/config/initializers/sidekiq.rb
+++ b/ruby/rails7-sidekiq/app/config/initializers/sidekiq.rb
@@ -1,5 +1,6 @@
 Sidekiq.configure_server do |config|
   console_logger = ActiveSupport::Logger.new(STDOUT)
-  config.logger = console_logger.extend(ActiveSupport::Logger.broadcast(Appsignal::Logger.new("sidekiq")))
+  appsignal_logger = Appsignal::Logger.new("sidekiq")
+  config.logger = ActiveSupport::BroadcastLogger.new(console_logger, appsignal_logger)
   config.logger.formatter = Sidekiq::Logger::Formatters::WithoutTimestamp.new
 end


### PR DESCRIPTION
Rails 7.1.1 removed the old `ActiveSupport::Logger.broadcast()` in favor of the new `ActiveSupport::BroadcastLogger`. Switch to that so that the test setup works with Rails 7.1.1 and above.