### PR TITLE
Add `Ecto.Multi` transactions endpoint

### DIFF
--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/controllers/page_controller.ex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/controllers/page_controller.ex
@@ -132,4 +132,23 @@ defmodule AppsignalPhoenixExampleWeb.PageController do
         "response status code is #{response.status}"
     )
   end
+
+  def transactions(conn, _params) do
+    {:ok, _} = Ecto.Multi.new()
+    |> Ecto.Multi.insert(:first, User.changeset(%User{}, %{age: 123, name: "Foo"}))
+    |> Ecto.Multi.insert(:second, User.changeset(%User{}, %{age: 456, name: "Bar"}))
+    |> Ecto.Multi.insert(:third, User.changeset(%User{}, %{age: 789, name: "Baz"}))
+    |> AppsignalPhoenixExample.Repo.transaction()
+
+    {:error, _, _, _} = Ecto.Multi.new()
+    |> Ecto.Multi.insert(:first, User.changeset(%User{}, %{age: 123, name: "Foo"}))
+    |> Ecto.Multi.insert(:second, User.changeset(%User{}, %{age: 456, name: "Bar"}))
+    |> Ecto.Multi.run(:fail, fn _repo, _ -> {:error, {:just, :because}} end)
+    |> AppsignalPhoenixExample.Repo.transaction()
+
+    text(
+      conn,
+      "Performed a successful and a failed Ecto.Multi transaction"
+    )
+  end
 end

--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/router.ex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/router.ex
@@ -23,6 +23,7 @@ defmodule AppsignalPhoenixExampleWeb.Router do
     get "/backtrace_error", PageController, :backtrace_error
     get "/custom_instrumentation", PageController, :custom_instrumentation
     get "/finch", PageController, :finch
+    get "/transactions", PageController, :transactions
     get "/tesla/vanilla", TeslaController, :vanilla
     get "/tesla/pathparams", TeslaController, :pathparams
     get "/tesla/withoutuse", TeslaController, :withoutuse

--- a/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/templates/page/index.html.eex
+++ b/elixir/phoenix-example/app/lib/appsignal_phoenix_example_web/templates/page/index.html.eex
@@ -9,6 +9,7 @@
   <li><a href="/tesla/withoutuse">/tesla/withoutuse</a> - Test an external request with Tesla (WithoutUse)</li>
   <li><a href="/tesla/pathparams">/tesla/pathparams</a> - Test an external request with Tesla (PathParams)</li>
   <li><a href="/custom_instrumentation">/custom_instrumentation</a> - Test custom instrumentation</li>
+  <li><a href="/transactions">/transactions</a> - Test Ecto transactions</li>
 </ul>
 
 <table>


### PR DESCRIPTION
Adds an endpoint to the Phoenix test setup that performs a successful and a failing `Ecto.Multi` transaction.