### PR TITLE
Remove (unintentional?) WSGI instrumentation

### DIFF
--- a/python/django4-celery/app/appsignal_python_opentelemetry/wsgi.py
+++ b/python/django4-celery/app/appsignal_python_opentelemetry/wsgi.py
@@ -9,10 +9,8 @@ https://docs.djangoproject.com/en/4.1/howto/deployment/wsgi/
 
 import os
 
-from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'appsignal_python_opentelemetry.settings')
 
 application = get_wsgi_application()
-application = OpenTelemetryMiddleware(application)


### PR DESCRIPTION
We're manually applying the WSGI instrumentation in `wsgi.py` in the Django test setup, alongside using `appsignal.start()` on `manage.py`. This results in event timelines that contain a WSGI span around the Django span.

For now, remove this, as this is not how we tell users to configure AppSignal in our documentation.

Screenshots of both timelines:

<img width="832" alt="Screenshot 2023-11-21 at 16 12 01" src="https://github.com/appsignal/test-setups/assets/45180344/e82e0dc7-9ac5-416d-9e21-4cc093ee65ad">
<img width="609" alt="Screenshot 2023-11-21 at 16 12 28" src="https://github.com/appsignal/test-setups/assets/45180344/ec7d9375-3c4e-4b28-957e-947d900758c6">

Note that, because the global HTTP extractor is not applied to Django spans, there are some attributes there that we should remove. See https://github.com/appsignal/appsignal-agent/pull/1081 for that.

Part of appsignal/appsignal-python#178, but not really.
