### PR TITLE
Remove duplicate app names from Node.js configs

### DIFF
--- a/nodejs/v3/express-apollo/app/src/appsignal.cjs
+++ b/nodejs/v3/express-apollo/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-express-apollo",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp"

--- a/nodejs/v3/express-mongoose/app/src/appsignal.cjs
+++ b/nodejs/v3/express-mongoose/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-express-mongoose",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp",

--- a/nodejs/v3/express-postgres/app/src/appsignal.cjs
+++ b/nodejs/v3/express-postgres/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-express-postgres",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp"

--- a/nodejs/v3/express-redis/app/src/appsignal.cjs
+++ b/nodejs/v3/express-redis/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-express-redis",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp"

--- a/nodejs/v3/express-yoga/app/src/appsignal.cjs
+++ b/nodejs/v3/express-yoga/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-express-yoga",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp"

--- a/nodejs/v3/fastify/app/src/appsignal.cjs
+++ b/nodejs/v3/fastify/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-fastify",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp",

--- a/nodejs/v3/koa-mongo/app/src/appsignal.cjs
+++ b/nodejs/v3/koa-mongo/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-koa-mongo",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp"

--- a/nodejs/v3/koa-mysql/app/src/appsignal.cjs
+++ b/nodejs/v3/koa-mysql/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-koa-mysql",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp"

--- a/nodejs/v3/nestjs/app/src/appsignal.cjs
+++ b/nodejs/v3/nestjs/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-nestjs",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp",

--- a/nodejs/v3/nextjs/app/appsignal.cjs
+++ b/nodejs/v3/nextjs/app/appsignal.cjs
@@ -2,8 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "nodejs/nextjs",
-  pushApiKey: "4ba6f264-d8e9-4e41-853e-15600e39e8b6",
   disableDefaultInstrumentations: [
     // Add the following line inside the list
     "@opentelemetry/instrumentation-http",

--- a/nodejs/v3/remix/app/appsignal.cjs
+++ b/nodejs/v3/remix/app/appsignal.cjs
@@ -3,7 +3,6 @@ const { RemixInstrumentation } = require("opentelemetry-instrumentation-remix");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-remix",
   additionalInstrumentations: [new RemixInstrumentation()],
-  disableDefaultInstrumentations: ["@opentelemetry/instrumentation-express"]
+  disableDefaultInstrumentations: ["@opentelemetry/instrumentation-express"],
 });

--- a/nodejs/v3/restify/app/src/appsignal.cjs
+++ b/nodejs/v3/restify/app/src/appsignal.cjs
@@ -2,7 +2,6 @@ const { Appsignal } = require("@appsignal/nodejs");
 
 new Appsignal({
   active: true,
-  name: "opentelemetry-restify",
   logLevel: "trace",
   log: "file",
   logPath: "/tmp"


### PR DESCRIPTION
We configure the app name using the `APPSIGNAL_APP_NAME` env var in the `docker-compose.yml` files. This overwrite in the file made the app report it using the wrong name.