### PR TITLE
Add Winston custom log levels example

### DIFF
--- a/nodejs/v3/express-redis/app/package-lock.json
+++ b/nodejs/v3/express-redis/app/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^4.17.2",
         "ioredis": "^4.28.5",
         "redis": "^4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.0",
+        "winston": "^3.8.2"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.3",

--- a/nodejs/v3/express-redis/app/src/app.ts
+++ b/nodejs/v3/express-redis/app/src/app.ts
@@ -43,9 +43,9 @@ app.use(cookieParser())
 
 app.get("/", (_req: any, res: any) => {
   logger.info("Home path");
-  logger.log("alert", "Custom alert log");
-  logger.log("emerg", "Custom emerg(ency) log");
-  logger.log("crit", "Custom crit(ical) log");
+  logger.alert("Custom alert log");
+  logger.emerg("Custom emerg(ency) log");
+  logger.crit("Custom crit(ical) log");
   res.send("200 OK")
 })
 

--- a/nodejs/v3/express-redis/app/src/app.ts
+++ b/nodejs/v3/express-redis/app/src/app.ts
@@ -5,9 +5,33 @@ import { setTag, setCustomData, expressErrorHandler, WinstonTransport } from "@a
 import { trace } from "@opentelemetry/api"
 import cookieParser from "cookie-parser"
 import winston from "winston"
+const { combine, label, printf } = winston.format;
+
+const customLogLevels = {
+  levels: {
+    trace: 8,
+    debug: 7,
+    info: 6,
+    notice: 5,
+    warn: 4,
+    error: 3,
+    crit: 2,
+    alert: 1,
+    emerg: 0,
+  },
+};
+
+const customformat = printf(({ level, message, label, timestamp }) => {
+  return `${timestamp} [${label}] ${level}: ${message}`;
+});
 
 const logger = winston.createLogger({
-  transports: [new WinstonTransport({ group: "app" })],
+  level: "trace",
+  levels: customLogLevels.levels,
+  format: combine(customformat),
+  transports: [
+    new WinstonTransport({ group: "app" }),
+  ],
 });
 
 const redisHost = "redis://redis:6379"
@@ -19,6 +43,9 @@ app.use(cookieParser())
 
 app.get("/", (_req: any, res: any) => {
   logger.info("Home path");
+  logger.log("alert", "Custom alert log");
+  logger.log("emerg", "Custom emerg(ency) log");
+  logger.log("crit", "Custom crit(ical) log");
   res.send("200 OK")
 })
 


### PR DESCRIPTION
Debug custom log level easier in the future by adding it to the example.

- [Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/4356044/conversation/16410700259720#part_id=comment-16410700259720-21909542604)
- [Slack discussion](https://appsignal.slack.com/archives/C7XHXQ7N0/p1701328390811769)