### PR TITLE
Fix Prisma migrate command

### DIFF
--- a/nodejs/nestjs-prisma/commands/run
+++ b/nodejs/nestjs-prisma/commands/run
@@ -27,7 +27,7 @@ echo "Building app"
 npm run build
 
 echo "Migrating Prisma database"
-npx prisma migrate dev
+npx prisma migrate deploy
 
 echo "Starting test app server"
 /commands/processmon processmon.toml


### PR DESCRIPTION
The dev command also prompts to generate a new migration, which hangs the CI build.

Use the deploy command to only run the migrations.

https://www.prisma.io/docs/orm/prisma-migrate/workflows/development-and-production

[skip review]