### PR TITLE
Add nested error to Sinatra test setup

### DIFF
--- a/ruby/sinatra/app/app.rb
+++ b/ruby/sinatra/app/app.rb
@@ -22,10 +22,16 @@ get "/slow" do
   "ZzZzZzZ.."
 end
 
+def original_error
+  raise "I am the original error!"
+end
+
 get "/error" do
   Appsignal.add_breadcrumb("test", "action")
   Appsignal.add_breadcrumb("category", "action", "message", { "metadata_key" => "some value" })
-  raise "error"
+  original_error
+rescue
+  raise "I am a wrapper error!"
 end
 
 get "/item/:id" do

--- a/support/processmon/Dockerfile
+++ b/support/processmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68.1-alpine3.17
+FROM rust:1.74.1-alpine3.17
 
 RUN apk update
 RUN apk add musl-dev


### PR DESCRIPTION
### [Bump up processmon's builder Rust version](https://github.com/appsignal/test-setups/commit/975fa03062b78383425d1c0358a1d58809e63c42)

Some transitive dependency of `processmon` (`colored`?) only
supports Ruby 1.70 or higher on its latest version. Bump the Rust
version in the processmon builder image to the latest Rust version
to work around it.

### [Add nested error to Sinatra test setup](https://github.com/appsignal/test-setups/commit/00d5e313e5a757e2c1586f1ce93af7d81400a746)

Make `/error` report a nested error, showcasing support for the
error causes feature implemented in AppSignal for Ruby 3.5.0.