### PR TITLE
Update Python app to work with public endpoint

### DIFF
--- a/python/django4-celery/app/appsignal_python_opentelemetry/views.py
+++ b/python/django4-celery/app/appsignal_python_opentelemetry/views.py
@@ -55,8 +55,17 @@ def slow(request):
 
 
 def slow_queue(request):
-    performance_task.delay("argument 1", "argument 2")
-    performance_task2.delay("argument 3", "argument 4")
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("Queue tasks"):
+        set_category("add_to_queue.tasks")
+
+        performance_task.delay("argument 1", "argument 2")
+
+        with tracer.start_as_current_span("Sleep"):
+            set_category("custom.sleep")
+            time.sleep(0.2)
+
+        performance_task2.delay("argument 3", "argument 4")
     return HttpResponse("I queued an performance_task!")
 
 

--- a/python/django4-celery/app/manage.py
+++ b/python/django4-celery/app/manage.py
@@ -9,6 +9,7 @@ from __appsignal__ import appsignal
 
 def main():
     """Run administrative tasks."""
+    os.environ["OTEL_SERVICE_NAME"] = "django-app"
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'appsignal_python_opentelemetry.settings')
 
     appsignal.start()

--- a/python/django4-celery/app/tasks.py
+++ b/python/django4-celery/app/tasks.py
@@ -1,4 +1,5 @@
 import time
+import os
 
 from __appsignal__ import appsignal
 
@@ -10,6 +11,7 @@ from celery.signals import worker_process_init
 
 @worker_process_init.connect(weak=False)
 def init_celery_tracing(*args, **kwargs):
+    os.environ["OTEL_SERVICE_NAME"] = "celery-app"
     appsignal.start()
 
 app = Celery('tasks', broker='redis://redis')
@@ -24,14 +26,14 @@ def performance_task(argument1, argument2):
     r = redis.Redis(host='redis', port=6379, db=0)
     r.set('some_key', 'some_value')
     redis_value = r.get('some_key')
-    time.sleep(1)
+    time.sleep(0.2)
 
 @app.task
 def performance_task2(argument1, argument2):
     r = redis.Redis(host='redis', port=6379, db=0)
     r.set('some_key2', 'some_value2')
     redis_value = r.get('some_key2')
-    time.sleep(1)
+    time.sleep(0.5)
 
 @app.task
 def error_task():

--- a/python/django4-celery/docker-compose.yml
+++ b/python/django4-celery/docker-compose.yml
@@ -3,14 +3,10 @@ version: '3.8'
 services:
   postgres:
     image: postgres
-    ports:
-      - "5432:5432"
     env_file:
       - postgres.env
   redis:
     image: "redis:6.2.7"
-    ports:
-      - "6379:6379"
   app:
     build: .
     image: python/django4-celery


### PR DESCRIPTION
Configure the service names for Django and Celery so they don't show up as "unknown service" in the UI.

To actually send OpenTelemetry protocol data to the staging public endpoint, the Python integrations repo also needs to be checked out on the right branch.