### PR TITLE
Add Sinatra + Alpine test setup

### DIFF
--- a/ruby/sinatra-alpine/Dockerfile
+++ b/ruby/sinatra-alpine/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:3.2-alpine3.19
+
+# Update this if the docker image changes
+ENV REFRESHED_AT=2023-06-22
+
+RUN apk add nodejs npm git build-base bash
+
+# RUN apk add alpine-sdk coreutils bash
+
+# Copy commands into the container
+RUN mkdir /commands
+COPY ./commands/* /commands/
+RUN chmod +x /commands/*
+
+# Run the app
+CMD /commands/run

--- a/ruby/sinatra-alpine/app/Gemfile
+++ b/ruby/sinatra-alpine/app/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "webrick"
+gem "appsignal", :path => "/integration"
+gem "activesupport", "5.2.0"
+gem "actionmailer", "5.2.0"
+
+gem "pry"

--- a/ruby/sinatra-alpine/app/Gemfile.lock
+++ b/ruby/sinatra-alpine/app/Gemfile.lock
@@ -1,0 +1,110 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionmailer (5.2.0)
+      actionpack (= 5.2.0)
+      actionview (= 5.2.0)
+      activejob (= 5.2.0)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.2.0)
+      actionview (= 5.2.0)
+      activesupport (= 5.2.0)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.0)
+      activesupport (= 5.2.0)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (5.2.0)
+      activesupport (= 5.2.0)
+      globalid (>= 0.3.6)
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    appsignal (3.4.14)
+      rack
+    builder (3.2.4)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.2)
+    crass (1.0.6)
+    date (3.3.3)
+    erubi (1.12.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    loofah (2.21.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    minitest (5.18.1)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
+    net-imap (0.3.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nokogiri (1.15.2-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.7.1)
+    rack (2.2.7)
+    rack-protection (3.0.6)
+      rack
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    ruby2_keywords (0.0.5)
+    sinatra (3.0.6)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.6)
+      tilt (~> 2.0)
+    thread_safe (0.3.6)
+    tilt (2.2.0)
+    timeout (0.4.0)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    webrick (1.8.1)
+
+PLATFORMS
+  aarch64-linux
+  x86_64-linux-musl
+
+DEPENDENCIES
+  actionmailer (= 5.2.0)
+  activesupport (= 5.2.0)
+  appsignal (= 3.4.14)
+  pry
+  sinatra
+  webrick
+
+BUNDLED WITH
+   2.2.33

--- a/ruby/sinatra-alpine/app/app.rb
+++ b/ruby/sinatra-alpine/app/app.rb
@@ -1,0 +1,39 @@
+require "active_support"
+require "action_mailer"
+require "sinatra"
+require "appsignal"
+require "appsignal/integrations/sinatra"
+
+get "/" do
+  time = Time.now.strftime("%H:%M")
+  <<~HTML
+    <h1>Sinatra example app</h1>
+
+    <ul>
+      <li><a href="/slow?time=#{time}">Slow request</a></li>
+      <li><a href="/error?time=#{time}">Error request</a></li>
+      <li><a href="/item/123?time=#{time}">Route with param request</a></li>
+    </ul>
+  HTML
+end
+
+get "/slow" do
+  sleep 3
+  "ZzZzZzZ.."
+end
+
+def original_error
+  raise "I am the original error!"
+end
+
+get "/error" do
+  Appsignal.add_breadcrumb("test", "action")
+  Appsignal.add_breadcrumb("category", "action", "message", { "metadata_key" => "some value" })
+  original_error
+rescue
+  raise "I am a wrapper error!"
+end
+
+get "/item/:id" do
+  "Item with id #{params[:id]}"
+end

--- a/ruby/sinatra-alpine/app/config.ru
+++ b/ruby/sinatra-alpine/app/config.ru
@@ -1,0 +1,2 @@
+require "./app"
+run Sinatra::Application

--- a/ruby/sinatra-alpine/app/config/appsignal.yml
+++ b/ruby/sinatra-alpine/app/config/appsignal.yml
@@ -1,0 +1,11 @@
+default: &defaults
+  filter_metadata: ["path"]
+
+test:
+  <<: *defaults
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/ruby/sinatra-alpine/app/processmon.toml
+++ b/ruby/sinatra-alpine/app/processmon.toml
@@ -1,0 +1,15 @@
+[[paths_to_watch]]
+path = "/app"
+
+[[paths_to_watch]]
+path = "/integration"
+
+[processes.app]
+command = "bundle"
+args = [
+  "exec",
+  "rackup",
+  "--host=0.0.0.0",
+  "--port=4001"
+]
+working_dir = "/app"

--- a/ruby/sinatra-alpine/commands/diagnose
+++ b/ruby/sinatra-alpine/commands/diagnose
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /app
+bundle exec appsignal diagnose --environment=production

--- a/ruby/sinatra-alpine/commands/run
+++ b/ruby/sinatra-alpine/commands/run
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "Install appsignal"
+(
+  cd /integration
+  rake extension:install
+)
+
+cd /app
+
+echo "Install dependencies"
+bundle config set path vendor/bundle
+bundle install --verbose
+
+echo "Starting app"
+/commands/processmon processmon.toml

--- a/ruby/sinatra-alpine/docker-compose.yml
+++ b/ruby/sinatra-alpine/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    image: ruby/sinatra
+    ports:
+      - "4001:4001"
+    environment:
+      - APPSIGNAL_APP_NAME=ruby-sinatra-alpine
+      - PORT=4001
+    env_file:
+      - ../../appsignal.env
+      - ../../appsignal_key.env
+    volumes:
+      - ./app:/app
+      - ../integration:/integration
+  tests:
+    build: ../../support/server-tests
+    image: server-tests
+    profiles:
+      - tests
+    depends_on:
+      - app
+    environment:
+      - APP_NAME=ruby/sinatra-alpine
+      - APP_URL=http://app:4001


### PR DESCRIPTION
This was implemented to research appsignal/appsignal-ruby#1017. It is a shameless copy-paste of the Sinatra test setup. Nonetheless, it's a nice addition.

Tests should pass because the Alpine issue does not affect the latest version of the integrations.