### PR TITLE
Update Python app AppSignal config location

### DIFF
--- a/python/django4-celery/app/__appsignal__.py
+++ b/python/django4-celery/app/__appsignal__.py
@@ -2,6 +2,5 @@ from appsignal import Appsignal
 
 appsignal = Appsignal(
     active=True,
-    name="python/django4-celery",
     environment="development",
 )

--- a/python/django4-celery/docker-compose.yml
+++ b/python/django4-celery/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ../../appsignal_key.env
     environment:
       - PORT=4001
+      - APP_NAME=python/django4-celery
     volumes:
       - ./app:/app
       - ../integration:/integration

--- a/python/fastapi/app/__appsignal__.py
+++ b/python/fastapi/app/__appsignal__.py
@@ -2,7 +2,5 @@ from appsignal import Appsignal
 
 appsignal = Appsignal(
     active=True,
-    name="python/fastapi",
     environment="development",
-    log_level="trace",
 )

--- a/python/fastapi/docker-compose.yml
+++ b/python/fastapi/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ../../appsignal_key.env
     environment:
       - PORT=4001
+      - APP_NAME=python/fastapi
     volumes:
       - ./app:/app
       - ../integration:/integration

--- a/python/flask/app/__appsignal__.py
+++ b/python/flask/app/__appsignal__.py
@@ -2,6 +2,5 @@ from appsignal import Appsignal
 
 appsignal = Appsignal(
     active=True,
-    name="python/flask",
     environment="development",
 )

--- a/python/flask/docker-compose.yml
+++ b/python/flask/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ../../appsignal_key.env
     environment:
       - PORT=4001
+      - APP_NAME=python/flask
     volumes:
       - ./app:/app
       - ../integration:/integration

--- a/python/starlette/app/__appsignal__.py
+++ b/python/starlette/app/__appsignal__.py
@@ -2,7 +2,5 @@ from appsignal import Appsignal
 
 appsignal = Appsignal(
     active=True,
-    name="python/starlette",
     environment="development",
-    log_level="trace",
 )

--- a/python/starlette/docker-compose.yml
+++ b/python/starlette/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ../../appsignal_key.env
     environment:
       - PORT=4001
+      - APP_NAME=python/starlette
     volumes:
       - ./app:/app
       - ../integration:/integration


### PR DESCRIPTION
Move all the config to env vars declared in the `docker-compose.yml` files, like we do for the other apps.

Remove `log_level` config from the config files, because it's configured in the `appsignal.env` file in the root already.

[skip review]