### PR TITLE
Update Alpine Linux build dependencies

### DIFF
--- a/elixir/alpine-release/Dockerfile
+++ b/elixir/alpine-release/Dockerfile
@@ -14,8 +14,10 @@ RUN apk update && \
       openssl-dev \
       netcat-openbsd \
       git \
-      alpine-sdk \
-      coreutils \
+      make \
+      gcc \
+      musl-dev \
+      musl-utils \
       inotify-tools \
       nodejs \
       npm \

--- a/ruby/sinatra-alpine/Dockerfile
+++ b/ruby/sinatra-alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.2.2-alpine3.19
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-12-15
 
-RUN apk add --no-cache alpine-sdk coreutils less
+RUN apk add --no-cache make gcc musl-dev musl-utils git less
 
 # Copy commands into the container
 RUN mkdir /commands


### PR DESCRIPTION
Use a smaller set of build dependencies for apps on Alpine Linux.

- Related docs update: https://github.com/appsignal/appsignal-docs/pull/1692
- Related issue: https://github.com/appsignal/appsignal-docs/issues/161

[skip review]