### PR TITLE
Add streaming endpoints for Rails/Sinatra

### DIFF
--- a/ruby/jruby-rails6/app/config/routes.rb
+++ b/ruby/jruby-rails6/app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "/slow", to: "tests#slow"
   get "/error", to: "tests#error"
+  get "/streaming-error", to: "tests#streaming_error_in_body"
 end

--- a/ruby/rails6-mongo/app/config/routes.rb
+++ b/ruby/rails6-mongo/app/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   get "/slow", to: "tests#slow"
   get "/error", to: "tests#error"
+  get "/streaming-error", to: "tests#streaming_error_in_body"
 
   resources :posts, :except => %i[edit update destroy]
 end

--- a/ruby/rails6-mysql/app/config/routes.rb
+++ b/ruby/rails6-mysql/app/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get "/slow", to: "tests#slow"
   get "/error", to: "tests#error"
+  get "/streaming-error", to: "tests#streaming_error_in_body"
 
   resources :posts, :except => %i[edit update destroy]
 end

--- a/ruby/rails6-shoryuken/app/config/routes.rb
+++ b/ruby/rails6-shoryuken/app/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get "/slow", to: "tests#slow"
   get "/error", to: "tests#error"
+  get "/streaming-error", to: "tests#streaming_error_in_body"
   get "/active_job_performance_job", to: "tests#active_job_performance_job"
   get "/active_job_error_job", to: "tests#active_job_error_job"
   root :to => "tests#index"

--- a/ruby/rails7-delayed-job/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-delayed-job/app/app/controllers/examples_controller.rb
@@ -10,6 +10,7 @@ class ExamplesController < ApplicationController
   class StreamingBody
     def each
       yield "1"
+      sleep 0.5
       yield "2"
       yield "3"
       raise "Rails error in streaming body"

--- a/ruby/rails7-delayed-job/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-delayed-job/app/app/controllers/examples_controller.rb
@@ -6,4 +6,18 @@ class ExamplesController < ApplicationController
   def error
     raise "This is a Rails error!"
   end
+
+  class StreamingBody
+    def each
+      yield "1"
+      yield "2"
+      yield "3"
+      raise "Rails error in streaming body"
+    end
+  end
+
+  def streaming_error_in_body
+    headers["Content-Length"] = "4"
+    response.body = StreamingBody.new
+  end
 end

--- a/ruby/rails7-goodjob/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-goodjob/app/app/controllers/examples_controller.rb
@@ -6,4 +6,18 @@ class ExamplesController < ApplicationController
   def error
     raise "This is a Rails error!"
   end
+
+  class StreamingBody
+    def each
+      yield "1"
+      yield "2"
+      yield "3"
+      raise "Rails error in streaming body"
+    end
+  end
+
+  def streaming_error_in_body
+    headers["Content-Length"] = "4"
+    response.body = StreamingBody.new
+  end
 end

--- a/ruby/rails7-goodjob/app/config/routes.rb
+++ b/ruby/rails7-goodjob/app/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   root :to => "examples#index"
   get "/slow", to: "examples#slow"
   get "/error", to: "examples#error"
+  get "/streaming-error", to: "examples#streaming_error_in_body"
 end

--- a/ruby/rails7-postgres/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-postgres/app/app/controllers/examples_controller.rb
@@ -10,6 +10,7 @@ class ExamplesController < ApplicationController
   class StreamingBody
     def each
       yield "1"
+      sleep 0.5
       yield "2"
       yield "3"
       raise "Rails error in streaming body"

--- a/ruby/rails7-postgres/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-postgres/app/app/controllers/examples_controller.rb
@@ -6,4 +6,18 @@ class ExamplesController < ApplicationController
   def error
     raise "This is a Rails error!"
   end
+
+  class StreamingBody
+    def each
+      yield "1"
+      yield "2"
+      yield "3"
+      raise "Rails error in streaming body"
+    end
+  end
+
+  def streaming_error_in_body
+    headers["Content-Length"] = "4"
+    response.body = StreamingBody.new
+  end
 end

--- a/ruby/rails7-postgres/app/config/routes.rb
+++ b/ruby/rails7-postgres/app/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   root :to => "examples#index"
   get "/slow", to: "examples#slow"
   get "/error", to: "examples#error"
+  get "/streaming-error", to: "examples#streaming_error_in_body"
   resources :items
 end

--- a/ruby/rails7-sequel/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-sequel/app/app/controllers/examples_controller.rb
@@ -10,6 +10,7 @@ class ExamplesController < ApplicationController
   class StreamingBody
     def each
       yield "1"
+      sleep 0.5
       yield "2"
       yield "3"
       raise "Rails error in streaming body"

--- a/ruby/rails7-sequel/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-sequel/app/app/controllers/examples_controller.rb
@@ -6,4 +6,18 @@ class ExamplesController < ApplicationController
   def error
     raise "This is a Rails error!"
   end
+
+  class StreamingBody
+    def each
+      yield "1"
+      yield "2"
+      yield "3"
+      raise "Rails error in streaming body"
+    end
+  end
+
+  def streaming_error_in_body
+    headers["Content-Length"] = "4"
+    response.body = StreamingBody.new
+  end
 end

--- a/ruby/rails7-sequel/app/config/routes.rb
+++ b/ruby/rails7-sequel/app/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   root :to => "examples#index"
   get "/slow", to: "examples#slow"
   get "/error", to: "examples#error"
+  get "/streaming-error", to: "examples#streaming_error_in_body"
   resources :users
 end

--- a/ruby/rails7-sidekiq/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-sidekiq/app/app/controllers/examples_controller.rb
@@ -10,6 +10,7 @@ class ExamplesController < ApplicationController
   class StreamingBody
     def each
       yield "1"
+      sleep 0.5
       yield "2"
       yield "3"
       raise "Rails error in streaming body"

--- a/ruby/rails7-sidekiq/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-sidekiq/app/app/controllers/examples_controller.rb
@@ -7,6 +7,20 @@ class ExamplesController < ApplicationController
     raise "This is a Rails error!"
   end
 
+  class StreamingBody
+    def each
+      yield "1"
+      yield "2"
+      yield "3"
+      raise "Rails error in streaming body"
+    end
+  end
+
+  def streaming_error_in_body
+    headers["Content-Length"] = "4"
+    response.body = StreamingBody.new
+  end
+
   def error_reporter
     Rails.error.handle do
       1 + '1' # raises TypeError

--- a/ruby/rails7-sidekiq/app/config/routes.rb
+++ b/ruby/rails7-sidekiq/app/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   root :to => "examples#index"
   get "/slow", to: "examples#slow"
   get "/error", to: "examples#error"
+  get "/streaming-error", to: "examples#streaming_error_in_body"
   get "/error_reporter", to: "examples#error_reporter"
   get "/queries", to: "examples#queries"
 end

--- a/ruby/rails7-solid-cache/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-solid-cache/app/app/controllers/examples_controller.rb
@@ -10,6 +10,7 @@ class ExamplesController < ApplicationController
   class StreamingBody
     def each
       yield "1"
+      sleep 0.5
       yield "2"
       yield "3"
       raise "Rails error in streaming body"

--- a/ruby/rails7-solid-cache/app/app/controllers/examples_controller.rb
+++ b/ruby/rails7-solid-cache/app/app/controllers/examples_controller.rb
@@ -6,4 +6,18 @@ class ExamplesController < ApplicationController
   def error
     raise "This is a Rails error!"
   end
+
+  class StreamingBody
+    def each
+      yield "1"
+      yield "2"
+      yield "3"
+      raise "Rails error in streaming body"
+    end
+  end
+
+  def streaming_error_in_body
+    headers["Content-Length"] = "4"
+    response.body = StreamingBody.new
+  end
 end

--- a/ruby/rails7-solid-cache/app/config/routes.rb
+++ b/ruby/rails7-solid-cache/app/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   root :to => "examples#index"
   get "/slow", to: "examples#slow"
   get "/error", to: "examples#error"
+  get "/streaming-error", to: "examples#streaming_error_in_body"
   resources :items
 end

--- a/ruby/sinatra-puma/app/app.rb
+++ b/ruby/sinatra-puma/app/app.rb
@@ -12,6 +12,7 @@ get "/" do
     <ul>
       <li><a href="/slow?time=#{time}">Slow request</a></li>
       <li><a href="/error?time=#{time}">Error request</a></li>
+      <li><a href="/stream?time=#{time}">Error in response body</a></li>
     </ul>
   HTML
 end
@@ -23,4 +24,13 @@ end
 
 get "/error" do
   raise "error"
+end
+
+get "/stream" do
+  stream do |out|
+    out << "a"
+    sleep 0.5
+    out << "b"
+    raise "Ouch"
+  end
 end

--- a/ruby/sinatra-puma/app/app.rb
+++ b/ruby/sinatra-puma/app/app.rb
@@ -12,7 +12,7 @@ get "/" do
     <ul>
       <li><a href="/slow?time=#{time}">Slow request</a></li>
       <li><a href="/error?time=#{time}">Error request</a></li>
-      <li><a href="/stream?time=#{time}">Error in response body</a></li>
+      <li><a href="/stream?time=#{time}">Streaming response</a></li>
     </ul>
   HTML
 end


### PR DESCRIPTION
I've tried to use the prescribed setup but for some reason i.e. Puma inside Docker is not able to bind to the socket when I start it. There are also a few shenanigans because Sinatra installs 4.0.0 by default, which pulls in Rack 3. This makes for a good test case but I don't know whether Appsignal is Rack 3.x compatible as of now... it should be (esp. including the changes I am making in the agent) but could use extra verification.