### PR TITLE
Add heartbeats endpoint to `sinatra-puma`

### DIFF
--- a/ruby/sinatra-puma/app/app.rb
+++ b/ruby/sinatra-puma/app/app.rb
@@ -14,6 +14,7 @@ get "/" do
       <li><a href="/error?time=#{time}">Error request</a></li>
       <li><a href="/stream/slow?time=#{time}">Slow streaming request</a></li>
       <li><a href="/stream/error?time=#{time}">Streaming request with error</a></li>
+      <li><a href="/heartbeat?time=#{time}">Custom heartbeat</a></li>
     </ul>
   HTML
 end
@@ -45,4 +46,12 @@ get "/stream/error" do
     out << "b"
     raise "Sinatra error in streaming body"
   end
+end
+
+get "/heartbeat" do
+  Appsignal.heartbeat("custom-heartbeat") do
+    sleep 3
+  end
+
+  "Heartbeat sent!"
 end

--- a/ruby/sinatra-puma/app/config/puma.rb
+++ b/ruby/sinatra-puma/app/config/puma.rb
@@ -17,7 +17,7 @@ environment "production"
 # Set up socket location
 bind "unix:///#{shared_dir}/sockets/puma.sock"
 
-stdout_redirect "#{shared_dir}/log/puma.stdout.log", "#{shared_dir}/log/puma.stderr.log", true
+# stdout_redirect "#{shared_dir}/log/puma.stdout.log", "#{shared_dir}/log/puma.stderr.log", true
 
 pidfile "#{shared_dir}/pids/puma.pid"
 state_path "#{shared_dir}/pids/puma.state"


### PR DESCRIPTION
See https://github.com/appsignal/appsignal-ruby/pull/1057 for context.

### [Add heartbeats endpoint to sinatra-puma](https://github.com/appsignal/test-setups/commit/b4e9add12800416477acb2b64020b789abe1e249)

### [Disable Puma stdout redirection](https://github.com/appsignal/test-setups/commit/1101ebfa67e7fe39c0861998f1450b0231d822e4)

It's kind of annoying to not see any output in the terminal and have
go look at this file instead. Standard output as standard output is
fine.