### PR TITLE
Remove the explicitly set --platform when building processmon

### DIFF
--- a/support/processmon/build.sh
+++ b/support/processmon/build.sh
@@ -3,7 +3,7 @@
 set -eu
 
 rm -f processmon
-docker build --platform linux/amd64 -t processmon:latest .
+docker build -t processmon:latest .
 docker run --rm -i -v ${PWD}:/mount processmon:latest sh -s <<EOF
   cp /usr/local/cargo/bin/processmon /mount/
 EOF


### PR DESCRIPTION
Currently, the processmon build script explicitly sets --platform to linux/amd64, which breaks on arm:

    ~/work/appsignal/test-setups $ rake app=ruby/rails7-delayed-job app:up
    Processmon not present. Building processmon...
    Running 'cd support/processmon && ./build.sh'
    [+] Building 0.5s (5/7)                                                           docker:desktop-linux
     => [internal] load build definition from Dockerfile                                              0.0s
     => => transferring dockerfile: 219B                                                              0.0s
     => [internal] load metadata for docker.io/library/rust:1.74.1-alpine3.17                         0.4s
     => [internal] load .dockerignore                                                                 0.0s
     => => transferring context: 2B                                                                   0.0s
     => CACHED [1/4] FROM docker.io/library/rust:1.74.1-alpine3.17@sha256:d45bc42990950fff3a37c0e7e4  0.0s
     => ERROR [2/4] RUN apk update                                                                    0.1s
    ------
     > [2/4] RUN apk update:
    0.084 exec /bin/sh: exec format error
    ------
    Dockerfile:3
    --------------------
       1 |     FROM rust:1.74.1-alpine3.17
       2 |
       3 | >>> RUN apk update
       4 |     RUN apk add musl-dev
       5 |
    --------------------
    ERROR: failed to solve: process "/bin/sh -c apk update" did not complete successfully: exit code: 1

Removing the --platform fixes the problem on my machine.