### PR TITLE
Add heartbeat to `express-redis`

### DIFF
--- a/nodejs/express-apollo/commands/run
+++ b/nodejs/express-apollo/commands/run
@@ -6,7 +6,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/express-mongoose/commands/run
+++ b/nodejs/express-mongoose/commands/run
@@ -14,7 +14,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/express-redis-alpine/commands/run
+++ b/nodejs/express-redis-alpine/commands/run
@@ -5,7 +5,6 @@ set -eu
 echo "Install, link and build integration"
 (
   cd /integration
-  git checkout main
   touch ~/.bashrc # hack to make the mono installer happy
   script/setup
   mono bootstrap

--- a/nodejs/express-redis/app/src/app.ts
+++ b/nodejs/express-redis/app/src/app.ts
@@ -1,10 +1,11 @@
 import express from "express"
 import { createClient } from "redis"
 import ioredis from "ioredis"
-import { setTag, setCustomData, expressErrorHandler, WinstonTransport } from "@appsignal/nodejs"
+import { setTag, setCustomData, expressErrorHandler, WinstonTransport, heartbeat } from "@appsignal/nodejs"
 import { trace } from "@opentelemetry/api"
 import cookieParser from "cookie-parser"
 import winston from "winston"
+
 const { combine, label, printf } = winston.format;
 
 const customLogLevels = {
@@ -110,6 +111,14 @@ app.get("/slow", async (_req: any, res: any) => {
 
 app.get("/route-param/:id", (req, res) => {
   res.send(`Route parameter <code>id</code>: ${req.params.id}`)
+})
+
+app.get("/heartbeat", async (req, res) => {
+  await heartbeat("custom-heartbeat", () => 
+    new Promise((resolve) => setTimeout(resolve, 3000))
+  )
+  
+  res.send("Heartbeat sent!")
 })
 
 app.use(expressErrorHandler())

--- a/nodejs/express-yoga/commands/run
+++ b/nodejs/express-yoga/commands/run
@@ -6,7 +6,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/fastify/commands/run
+++ b/nodejs/fastify/commands/run
@@ -6,7 +6,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/koa-mongo/commands/run
+++ b/nodejs/koa-mongo/commands/run
@@ -14,7 +14,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/koa-mysql/commands/run
+++ b/nodejs/koa-mysql/commands/run
@@ -6,7 +6,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/nestjs-prisma/commands/run
+++ b/nodejs/nestjs-prisma/commands/run
@@ -6,7 +6,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/nextjs-noappdir/commands/run
+++ b/nodejs/nextjs-noappdir/commands/run
@@ -14,7 +14,6 @@ npm install -g npm@latest
 # echo "Install, link and build integration"
 # (
 # cd /integration
-# git checkout main
 # touch ~/.bashrc # hack to make the mono installer happy
 # script/setup
 # mono bootstrap

--- a/nodejs/nextjs/commands/run
+++ b/nodejs/nextjs/commands/run
@@ -11,7 +11,6 @@ set -eu
 # echo "Install, link and build integration"
 # (
 # cd /integration
-# git checkout main
 # touch ~/.bashrc # hack to make the mono installer happy
 # script/setup
 # mono bootstrap

--- a/nodejs/remix/commands/run
+++ b/nodejs/remix/commands/run
@@ -6,7 +6,6 @@ echo "Install link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap

--- a/nodejs/restify/commands/run
+++ b/nodejs/restify/commands/run
@@ -6,7 +6,6 @@ echo "Install, link and build integration"
 (
 cd /integration
 git config --global --add safe.directory /integration # avoid git fatal errors about dubious ownership
-git checkout main
 touch ~/.bashrc # hack to make the mono installer happy
 script/setup
 mono bootstrap


### PR DESCRIPTION
This is a companion PR to the Heartbeats for Node.js one. No need to review it.

### [Do not checkout main on run command](https://github.com/appsignal/test-setups/commit/ce4276b21fee0f69439c0c22cf439599ddc113e3)

In order to be able to use the test setups to test against arbitrary
branches, they should not run `git checkout main` on the integration
repository.

### [Add heartbeats to express-redis test setup](https://github.com/appsignal/test-setups/commit/9f52333e0f0dd567e30a7f519ef46d121ff0f88f)