### PR TITLE
Revert "Add heartbeats to `flask` test setup"

### DIFF
--- a/python/flask/app/app.py
+++ b/python/flask/app/app.py
@@ -12,15 +12,13 @@ from appsignal import (
     set_gauge,
     increment_counter,
     add_distribution_value,
-    probes,
-    Heartbeat
+    probes
 )
 
 from flask import Flask, request
 app = Flask(__name__)
 
 from random import randrange
-from time import sleep
 
 def report_some_metrics():
     increment_counter("probe_counter", randrange(1, 100))
@@ -99,13 +97,6 @@ def metrics():
     add_distribution_value("some_histogram_with_tags", randrange(1, 100), {"tag1": "value1", "tag2": "value2"})
 
     return "<p>Emitted some custom metrics!</p>"
-
-@app.route("/heartbeat")
-def heartbeat():
-    with Heartbeat("custom-heartbeat"):
-        sleep(3)
-
-    return "<p>Sent a heartbeat!</p>"
 
 @app.route("/custom", methods=["GET", "POST"])
 def custom():


### PR DESCRIPTION
Reverts appsignal/test-setups#197 so the build isn't broken until https://github.com/appsignal/appsignal-python/pull/203 is merged.

[skip review]