### PR TITLE
Fix test setups

### DIFF
--- a/nodejs/koa-mysql/docker-compose.yml
+++ b/nodejs/koa-mysql/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   mysql:
-    image: mysql
+    image: mysql:8.3
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     env_file:

--- a/ruby/jruby-rails6/Dockerfile
+++ b/ruby/jruby-rails6/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.4.2.0
+FROM jruby:9.4.7.0-jre11
 
 # Update this if the Docker image changes
 ENV REFRESHED_AT=2022-02-24

--- a/ruby/jruby-rails6/app/Gemfile
+++ b/ruby/jruby-rails6/app/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.1.0'
+ruby '3.1.4'
 
 gem 'appsignal', :path => '/integration'
 


### PR DESCRIPTION
Buncha things broke, buncha things fixed. Life goes on.

### [Pin Koa + MySQL test setup to MySQL 8.3](https://github.com/appsignal/test-setups/commit/bed41a00fb81db744856d367e71297db64791de0)

The test setup uses the `mysql` library, which is not and will not
be compatible with the new authentication protocols in MySQL 8.4.

(The `mysql2` library does support those)

### [Bump JRuby to newer Java version](https://github.com/appsignal/test-setups/commit/634eae163eef6bf4df14341f13f07d4be116a7f0)

A newer version of `nio4r` does not play nicely with Java 8. Upgrade
to Java 11.