### PR TITLE
Add ViewComponent-based component

### DIFF
--- a/ruby/rails7-sequel/app/Gemfile
+++ b/ruby/rails7-sequel/app/Gemfile
@@ -68,4 +68,6 @@ end
 gem "sequel-rails", "~> 1.2"
 gem "pg", "~> 1.5"
 
+gem "view_component"
+
 gem "appsignal", :path => "/integration"

--- a/ruby/rails7-sequel/app/Gemfile.lock
+++ b/ruby/rails7-sequel/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /integration
   specs:
-    appsignal (3.4.13)
+    appsignal (3.6.4)
       rack
 
 GEM
@@ -135,6 +135,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.4)
     psych (5.1.0)
       stringio
@@ -210,6 +212,10 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    view_component (3.12.1)
+      activesupport (>= 5.2.0, < 8.0)
+      concurrent-ruby (~> 1.0)
+      method_source (~> 1.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -229,6 +235,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   appsignal!
@@ -246,6 +253,7 @@ DEPENDENCIES
   stimulus-rails
   turbo-rails
   tzinfo-data
+  view_component
   web-console
   webdrivers
 

--- a/ruby/rails7-sequel/app/app/components/example_component.rb
+++ b/ruby/rails7-sequel/app/app/components/example_component.rb
@@ -1,0 +1,9 @@
+class ExampleComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <h3>I am a ViewComponent! Just <%= @pastime %> here, please ignore me.</h3>
+  ERB
+
+  def initialize(pastime:)
+    @pastime = pastime
+  end
+end

--- a/ruby/rails7-sequel/app/app/views/users/index.html.erb
+++ b/ruby/rails7-sequel/app/app/views/users/index.html.erb
@@ -42,3 +42,5 @@
 <% else %>
   <p>No users found. Please create a user first</p>
 <% end %>
+
+<%= render(ExampleComponent.new(pastime: "chilling")) %>

--- a/ruby/rails7-sequel/app/config/application.rb
+++ b/ruby/rails7-sequel/app/config/application.rb
@@ -32,5 +32,7 @@ module SequelTest
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.view_component.instrumentation_enabled = true
+    config.view_component.use_deprecated_instrumentation_name = false
   end
 end


### PR DESCRIPTION
Add the `view_component` gem and render a ViewComponent-based component in an existing view. See [event formatter PR for context](https://github.com/appsignal/appsignal-ruby/pull/1082).