### PR TITLE
Add Hanami app to the CI build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -173,6 +173,9 @@ blocks:
         - name: ruby/jruby-rails6
           commands:
             - "rake app=ruby/jruby-rails6 app:test"
+        - name: ruby/hanami2-postgres
+          commands:
+            - "rake app=ruby/hanami2-postgres app:test"
         - name: ruby/padrino
           commands:
             - "rake app=ruby/padrino app:test"

--- a/ruby/hanami2-postgres/app/app/action.rb
+++ b/ruby/hanami2-postgres/app/app/action.rb
@@ -5,5 +5,17 @@ require "hanami/action"
 
 module Hanami2Postgres
   class Action < Hanami::Action
+    handle_exception StandardError => :handle_standard_error
+
+    private
+
+    def handle_standard_error(request, response, exception)
+      # Report the error to AppSignal
+      Appsignal.set_error(exception)
+
+      # Render custom error page
+      response.status = 500
+      response.body = "Sorry, something went wrong handling your request"
+    end
   end
 end

--- a/ruby/hanami2-postgres/app/app/actions/errors/show.rb
+++ b/ruby/hanami2-postgres/app/app/actions/errors/show.rb
@@ -1,9 +1,9 @@
 module Hanami2Postgres
   module Actions
-    module Home
+    module Errors
       class Show < Hanami2Postgres::Action
         def handle(request, response)
-          response.body = "Hello from action #{self.class.name}: #{request.params.to_h}"
+          raise "This is an error from an Hanami action"
         end
       end
     end

--- a/ruby/hanami2-postgres/app/app/actions/slow/show.rb
+++ b/ruby/hanami2-postgres/app/app/actions/slow/show.rb
@@ -1,9 +1,10 @@
 module Hanami2Postgres
   module Actions
-    module Home
+    module Slow
       class Show < Hanami2Postgres::Action
         def handle(request, response)
-          response.body = "Hello from action #{self.class.name}: #{request.params.to_h}"
+          sleep 3
+          response.body = "Well that was slow"
         end
       end
     end

--- a/ruby/hanami2-postgres/app/config/app.rb
+++ b/ruby/hanami2-postgres/app/config/app.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "hanami"
-require "appsignal"
 
 module Hanami2Postgres
   class App < Hanami::App

--- a/ruby/hanami2-postgres/app/config/routes.rb
+++ b/ruby/hanami2-postgres/app/config/routes.rb
@@ -3,6 +3,8 @@
 module Hanami2Postgres
   class Routes < Hanami::Routes
     root to: "home.show"
+    get "/slow", to: "slow.show"
+    get "/error", to: "errors.show"
     get "/books", to: "books.index"
     get "/books/:id", to: "books.show"
     post "/books", to: "books.create"

--- a/ruby/hanami2-postgres/app/processmon.toml
+++ b/ruby/hanami2-postgres/app/processmon.toml
@@ -5,8 +5,10 @@ path = "/app"
 path = "/integration"
 
 [processes.hanami]
-command = "hanami"
+command = "bundle"
 args = [
+  "exec",
+  "hanami",
   "server",
   "--host=0.0.0.0",
   "--port=4001"


### PR DESCRIPTION
The Hanami app wasn't added to the CI build yet and it didn't include routes for an example error and slow endpoint.

[skip review]