### PR TITLE
Remove old agent artifacts on integrations clone

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ def reset_repo(path, branch: "main")
     run_command "cd #{path} && git fetch origin"
     run_command "cd #{path} && git switch -f #{branch}"
     run_command "cd #{path} && git reset --hard origin/#{branch}"
+    run_command "cd #{path} && git clean -dfx ."
   else
     puts "#{path} not present"
   end


### PR DESCRIPTION
This fixes an issue where, after running `integrations:clone`, you end up with a newer version of the integration's source code, but an old version of the agent within it.

[skip review]