### PR TITLE
Avoid boot loop on NestJS + Prisma build

### DIFF
--- a/nodejs/nestjs-prisma/app/processmon.toml
+++ b/nodejs/nestjs-prisma/app/processmon.toml
@@ -1,6 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["prisma/dev.db", "prisma/dev.db-journal"]
+ignore = ["prisma/dev.db", "prisma/dev.db-journal", "dist"]
 
 [[paths_to_watch]]
 path = "/integration"


### PR DESCRIPTION
When booting the NestJS + Prisma test setup, the TypeScript code is compiled. Processmon picks up the outcome of the build as a change and triggers the build to restart, getting stuck in a loop.

I'm not sure why this doesn't happen in CI. This behaviour may be tied to the versions of the dependencies used -- I found this while testing it with `prisma@5.14.0`. Nonetheless, having Processmon ignore the `dist` folder makes sense.

[skip review]