### PR TITLE
Add Prisma migration

### DIFF
--- a/nodejs/nestjs-prisma/app/prisma/migrations/20240704123353_init/migration.sql
+++ b/nodejs/nestjs-prisma/app/prisma/migrations/20240704123353_init/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "name" TEXT
+);
+
+-- CreateTable
+CREATE TABLE "Post" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "content" TEXT,
+    "published" BOOLEAN DEFAULT false,
+    "authorId" INTEGER,
+    CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");


### PR DESCRIPTION
Generated automatically from the schema with `npx prisma migrate dev --name init`.

I'm not sure how this ever worked. Perhaps I had a migrated database locally, but I never actually committed the migration. It might also have to do with the newer version of Prisma I'm using to test this.

[skip review]