### PR TITLE
Add logging initialisers to Rails 8

### DIFF
--- a/ruby/rails8-sidekiq/app/config/initializers/logging.rb
+++ b/ruby/rails8-sidekiq/app/config/initializers/logging.rb
@@ -1,0 +1,3 @@
+Rails.application.config.log_tags = [:request_id]
+appsignal_logger = Appsignal::Logger.new("rails")
+Rails.logger.broadcast_to(appsignal_logger)

--- a/ruby/rails8-sidekiq/app/config/initializers/sidekiq.rb
+++ b/ruby/rails8-sidekiq/app/config/initializers/sidekiq.rb
@@ -1,0 +1,6 @@
+Sidekiq.configure_server do |config|
+  console_logger = ActiveSupport::Logger.new(STDOUT)
+  appsignal_logger = Appsignal::Logger.new("sidekiq")
+  config.logger = ActiveSupport::BroadcastLogger.new(console_logger, appsignal_logger)
+  config.logger.formatter = Sidekiq::Logger::Formatters::WithoutTimestamp.new
+end


### PR DESCRIPTION
Copy the logging initialisers for Rails and Sidekiq from the `ruby/rails7-sidekiq` test setup into the `ruby/rails8-sidekiq` test setup.

In the future, this might help us detect issues like appsignal/appsignal-ruby#1348 before they impact our customers.