### PR TITLE
Update Next.js setups to Node 20

### DIFF
--- a/nodejs/nextjs-13-app/Dockerfile
+++ b/nodejs/nextjs-13-app/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:18
+FROM node:20
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2023-03-28
+ENV REFRESHED_AT=2024-12-17
 
 # Install dependencies
 RUN apt-get update && apt-get install -y ruby less

--- a/nodejs/nextjs-14-app/Dockerfile
+++ b/nodejs/nextjs-14-app/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:18
+FROM node:20
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2023-03-28
+ENV REFRESHED_AT=2024-12-17
 
 # Install dependencies
 RUN apt-get update && apt-get install -y ruby less

--- a/nodejs/nextjs-14-pages/Dockerfile
+++ b/nodejs/nextjs-14-pages/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:18
+FROM node:20
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2023-03-28
+ENV REFRESHED_AT=2024-12-17
 
 # Install dependencies
 RUN apt-get update && apt-get install -y ruby less


### PR DESCRIPTION
Some of their transitive dependencies are no longer happy running on Node 18, which will be EOL in a few months anyway.

This fixes [the test failures on `main` CI](https://appsignal.semaphoreci.com/workflows/7094815e-70d7-4e85-b73d-194dddc06dde?pipeline_id=0386a25a-a3ad-4d3f-927d-50cb87810199) for the `nodejs/next-13-app`, `nodejs/next-14-app` and `nodejs/next-14-pages` test setups.