### PR TITLE
Update Webmachine test setups to Ruby 3.2.2

### DIFF
--- a/ruby/webmachine1/Dockerfile
+++ b/ruby/webmachine1/Dockerfile
@@ -1,7 +1,7 @@
-FROM ruby:3.0
+FROM ruby:3.2.2-bullseye
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2021-02-12
+ENV REFRESHED_AT=2024-12-17
 
 RUN apt-get update && apt-get install -y less
 

--- a/ruby/webmachine2/Dockerfile
+++ b/ruby/webmachine2/Dockerfile
@@ -1,7 +1,7 @@
-FROM ruby:3.0
+FROM ruby:3.2.2-bullseye
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2021-02-12
+ENV REFRESHED_AT=2024-12-17
 
 RUN apt-get update && apt-get install -y less
 


### PR DESCRIPTION
This fixes an issue where `gem update --system` fails because the
latest RubyGems version does not support Ruby 3.0.

---

### [Update Webmachine setups to Ruby 3.2.2](https://github.com/appsignal/test-setups/pull/247/commits/75afbebbb4dcdcd03c866effcc4b4773c58b580e)

Update the Webmachine test setups to Ruby 3.2.2.

---

This fixes [the test failures on `main` CI](https://appsignal.semaphoreci.com/workflows/7094815e-70d7-4e85-b73d-194dddc06dde?pipeline_id=0386a25a-a3ad-4d3f-927d-50cb87810199) for the `ruby/webmachine1` and `ruby/webmachine2` test setups.