### PR TITLE
Keep Rails 6 + Mongo RubyGems on 3.5.23

### DIFF
--- a/ruby/rails6-mongo/Dockerfile
+++ b/ruby/rails6-mongo/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
   apt-get install -y nodejs python2 && \
   npm install -g npm yarn
 
-RUN gem update --system && gem install bundler
+RUN gem update --system 3.5.23 && gem install bundler
 ENV BUNDLE_PATH=/app/vendor/bundle
 
 # Copy commands into the container


### PR DESCRIPTION
This test setup runs on Ruby 3.0.3, which is not supported by RubyGems 3.6.0.

Attempting to upgrade this test setup to Ruby 3.2.2, like the other Rails 6 test setups (see #247), surfaced some issue with Psych that I did not care to look into at this time.

---

This fixes [the test failures on main CI](https://appsignal.semaphoreci.com/workflows/7094815e-70d7-4e85-b73d-194dddc06dde?pipeline_id=0386a25a-a3ad-4d3f-927d-50cb87810199) for the `ruby/rails6-mongo` test setup.