### PR TITLE
Print which commit was cloned

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ def clone_from_git(path, repo, branch: nil)
     puts "Cloning #{repo} into #{path}"
     branch_arg = "--branch #{branch}" if branch
     run_command "git clone #{branch_arg} git@github.com:appsignal/#{repo}.git #{path}"
+    puts "Cloned #{repo} at #{path} is at commit #{`cd #{path} && git rev-parse HEAD`.strip}"
   end
 end
 


### PR DESCRIPTION
This will make it easier to track the range of possible changes that are responsible for a specific failure on the test setups' scheduled CI.