### PR TITLE
Add Ownership to Rails 8 + Sidekiq

### DIFF
--- a/ruby/rails8-sidekiq/app/Gemfile
+++ b/ruby/rails8-sidekiq/app/Gemfile
@@ -64,3 +64,4 @@ end
 
 gem "sidekiq"
 gem "appsignal", :path => "/integration"
+gem "ownership"

--- a/ruby/rails8-sidekiq/app/Gemfile.lock
+++ b/ruby/rails8-sidekiq/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /integration
   specs:
-    appsignal (4.1.2)
+    appsignal (4.3.2)
       logger
       rack
 
@@ -189,6 +189,7 @@ GEM
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     ostruct (0.6.1)
+    ownership (0.4.0)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -380,6 +381,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  ownership
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.0)

--- a/ruby/rails8-sidekiq/app/app/controllers/examples_controller.rb
+++ b/ruby/rails8-sidekiq/app/app/controllers/examples_controller.rb
@@ -1,6 +1,8 @@
 class ReportError < StandardError; end
 
 class ExamplesController < ApplicationController
+  owner :examples
+
   def index
     session[:user_id] = :some_user_id_123
     session[:menu] = { :state => :open, :view => :full }


### PR DESCRIPTION
See https://github.com/appsignal/appsignal-ruby/pull/1364. [skip review]

Add the `ownership` gem to the Rails 8 + Sidekiq test setup. Set the examples controller to be owned by the "examples" group.