### PR TITLE
Set up Rails 8 app logger according to our docs

### DIFF
--- a/ruby/rails8-sidekiq/app/config/initializers/logging.rb
+++ b/ruby/rails8-sidekiq/app/config/initializers/logging.rb
@@ -1,3 +1,5 @@
 Rails.application.config.log_tags = [:request_id]
+
 appsignal_logger = Appsignal::Logger.new("rails")
-Rails.logger.broadcast_to(appsignal_logger)
+appsignal_logger.broadcast_to(Rails.logger)
+Rails.logger = ActiveSupport::TaggedLogging.new(appsignal_logger)


### PR DESCRIPTION
Avoid confusion why things aren't working properly, like not silencing logs, by using the method described in our docs.

Following the steps in:
https://docs.appsignal.com/logging/integrations/ruby.html#using-multiple-logging-backends