### PR TITLE
Add app path config option to OTel apps

### DIFF
--- a/elixir/phoenix-collector/app/config/config.exs
+++ b/elixir/phoenix-collector/app/config/config.exs
@@ -73,10 +73,11 @@ config :opentelemetry,
   traces_exporter: :otlp,
   resource: [
     {"appsignal.config.name", System.get_env("APPSIGNAL_APP_NAME")},
-    {"appsignal.config.environment", Mix.env()},
+    {"appsignal.config.environment", to_string(Mix.env())},
     {"appsignal.config.push_api_key", System.get_env("APPSIGNAL_PUSH_API_KEY")},
     {"appsignal.config.revision", "test-setups"},
     {"appsignal.config.language_integration", "elixir"},
+    {"appsignal.config.app_path", File.cwd!()},
     {"service.name", "Phoenix"},
     {"host.name", hostname}
   ]

--- a/nodejs/express-postgres-collector/app/src/opentelemetry.cjs
+++ b/nodejs/express-postgres-collector/app/src/opentelemetry.cjs
@@ -23,6 +23,7 @@ const resource = new Resource({
   "appsignal.config.push_api_key": process.env.APPSIGNAL_PUSH_API_KEY,
   "appsignal.config.revision": "test-setups",
   "appsignal.config.language_integration": "node.js",
+  "appsignal.config.app_path": process.cwd(),
   "host.name": os.hostname(),
   // Customize the service name
   [SemanticResourceAttributes.SERVICE_NAME]: "Express server",

--- a/python/django5-celery-collector/app/appsignal_python_opentelemetry/opentelemetry.py
+++ b/python/django5-celery-collector/app/appsignal_python_opentelemetry/opentelemetry.py
@@ -45,6 +45,7 @@ class Appsignal:
             "host.name": socket.gethostname(),
             # Customize the service name
             "service.name": service_name,
+            "appsignal.config.app_path": os.getcwd(),
         })
         trace_provider = TracerProvider(resource=resource)
 

--- a/ruby/rails8-sidekiq-collector/app/config/initializers/opentelemetry.rb
+++ b/ruby/rails8-sidekiq-collector/app/config/initializers/opentelemetry.rb
@@ -11,6 +11,7 @@ OpenTelemetry::SDK.configure do |c|
     "appsignal.config.push_api_key" => ENV["APPSIGNAL_PUSH_API_KEY"],
     "appsignal.config.revision" => "test-setups",
     "appsignal.config.language_integration" => "ruby",
+    "appsignal.config.app_path" => Dir.pwd,
     "host.name" => Socket.gethostname,
   )
   # Customize the service name


### PR DESCRIPTION
Add this useful config option to the test app so we can test if it works once we implemented the whole feature.

Part of https://github.com/appsignal/appsignal-collector/issues/182

[skip review]