### PR TITLE
Remove metric aggregation temporality adjustments

### DIFF
--- a/java/spring-agent-collector/app/agent.properties
+++ b/java/spring-agent-collector/app/agent.properties
@@ -7,6 +7,3 @@ otel.logs.exporter=none
 # OTLP Endpoints
 otel.exporter.otlp.endpoint=http://appsignal-collector:8099
 otel.exporter.otlp.protocol=http/protobuf
-
-# Metric temporality settings
-otel.exporter.otlp.metrics.temporality.preference=delta

--- a/java/spring-native-collector/app/src/main/java/io/opentelemetry/example/graal/OpenTelemetryConfig.java
+++ b/java/spring-native-collector/app/src/main/java/io/opentelemetry/example/graal/OpenTelemetryConfig.java
@@ -97,14 +97,6 @@ public class OpenTelemetryConfig {
     if (exporter instanceof OtlpHttpMetricExporter) {
       return OtlpHttpMetricExporter.builder()
           .setEndpoint("http://appsignal-collector:8099/v1/metrics")
-          .setAggregationTemporalitySelector(instrumentType -> {
-            switch (instrumentType) {
-              case OBSERVABLE_GAUGE:
-                return AggregationTemporality.CUMULATIVE;
-              default:
-                return AggregationTemporality.DELTA;
-            }
-          })
           .build();
     }
     return exporter;

--- a/nodejs/express-postgres-collector/app/processmon.toml
+++ b/nodejs/express-postgres-collector/app/processmon.toml
@@ -1,5 +1,5 @@
 [[paths_to_watch]]
-path = "/app"
+path = "/app/src"
 
 [processes.node]
 command = "npm"

--- a/nodejs/express-postgres-collector/app/src/opentelemetry.cjs
+++ b/nodejs/express-postgres-collector/app/src/opentelemetry.cjs
@@ -44,24 +44,6 @@ const resource = new Resource({
 // Specify AppSignal collector location
 const collectorHost = "http://appsignal-collector:8099"
 
-// Custom metrics aggregation temporality selector
-// This requires a patch because the Node.js exporter doesn't allow this to be
-// specified per metric type.
-const customAggregationTemporality = {
-  COUNTER: AggregationTemporality.DELTA,
-  UP_DOWN_COUNTER: AggregationTemporality.DELTA,
-  OBSERVABLE_COUNTER: AggregationTemporality.DELTA,
-  OBSERVABLE_GAUGE: AggregationTemporality.CUMULATIVE,
-  OBSERVABLE_UP_DOWN_COUNTER: AggregationTemporality.DELTA,
-  HISTOGRAM: AggregationTemporality.DELTA
-}
-class PatchedOTLPMetricExporter extends OTLPMetricExporter {
-  selectAggregationTemporality(instrumentType) {
-    const aggregationTemporality = customAggregationTemporality[instrumentType]
-    return aggregationTemporality != undefined ? aggregationTemporality :
-      super.selectAggregationTemporality(instrumentType);
-  }
-}
 // Configure the OpenTelemetry HTTP exporter
 const sdk = new NodeSDK({
   resource,
@@ -70,7 +52,7 @@ const sdk = new NodeSDK({
   }),
   metricReader: new PeriodicExportingMetricReader({
     exportIntervalMillis: 1000,
-    exporter: new PatchedOTLPMetricExporter({
+    exporter: new OTLPMetricExporter({
       url: `${collectorHost}/v1/metrics`,
     })
   }),

--- a/python/django5-celery-collector/app/appsignal_python_opentelemetry/opentelemetry.py
+++ b/python/django5-celery-collector/app/appsignal_python_opentelemetry/opentelemetry.py
@@ -68,18 +68,8 @@ class Appsignal:
         trace_provider.add_span_processor(span_processor)
         trace.set_tracer_provider(trace_provider)
 
-        # Configure the OpenTelemetry HTTP metrics exporter
-        METRICS_PREFERRED_TEMPORALITY: dict[type, AggregationTemporality] = {
-            Counter: AggregationTemporality.DELTA,
-            UpDownCounter: AggregationTemporality.DELTA,
-            ObservableCounter: AggregationTemporality.DELTA,
-            ObservableGauge: AggregationTemporality.CUMULATIVE,
-            ObservableUpDownCounter: AggregationTemporality.DELTA,
-            Histogram: AggregationTemporality.DELTA,
-        }
         metric_exporter = OTLPMetricExporter(
             endpoint=f"{collector_host}/v1/metrics",
-            preferred_temporality=METRICS_PREFERRED_TEMPORALITY
         )
         metric_reader = PeriodicExportingMetricReader(
             metric_exporter,


### PR DESCRIPTION
See https://github.com/appsignal/appsignal-collector/pull/214.

---

### [Only watch `/app/src` folder](https://github.com/appsignal/test-setups/commit/21ca35d685ff4041ad7cc1355c404ccbb6f05070)

This fixes an issue where Processmon gets stuck in a restart loop
because it detects the consequences of its own command, which
re-creates the files in `/dist`, as changes.

### [Remove metric aggregation temporality adjustments](https://github.com/appsignal/test-setups/commit/f29193a33059ec1cd0d16b252ae02b535eac731e)

Remove metric aggregation temporality adjustments from any collector
test setups that have them. This simplifies the OpenTelemetry setup
for test setups that export metrics.

---

Is this a change we actually want to do? Data accuracy is slightly better for delta histograms over cumulative histograms, as minimum and maximum values are guaranteed to be usable explicit values in cumulative histograms -- but it doesn't make a big difference, especially if the metrics transmission interval is short. If it is, then:

### To do
- [ ] Update docs accordingly