### PR TITLE
Store Gin request query and payload

### DIFF
--- a/go/go-gin-mysql-collector/app/README.md
+++ b/go/go-gin-mysql-collector/app/README.md
@@ -1,1 +1,0 @@
-# opentelemetry-go-gin

--- a/go/go-gin-mysql-collector/app/main.go
+++ b/go/go-gin-mysql-collector/app/main.go
@@ -70,9 +70,9 @@ func initTracer() func(context.Context) error {
 		attribute.String("service.name", "Gin"),
 		attribute.String("host.name", hostname),
 		attribute.StringSlice("appsignal.config.filter_function_parameters", []string{"password", "token"}),
-		attribute.StringSlice("appsignal.config.filter_query_parameters", []string{"password", "token"}),
+		attribute.StringSlice("appsignal.config.filter_request_query_parameters", []string{"password", "token"}),
 		attribute.StringSlice("appsignal.config.filter_request_payload", []string{"password", "token"}),
-		attribute.StringSlice("appsignal.config.filter_session_data", []string{"password", "token"}),
+		attribute.StringSlice("appsignal.config.filter_request_session_data", []string{"password", "token"}),
 		// attribute.Bool("appsignal.config.send_function_parameters", false),
 	)
 


### PR DESCRIPTION
Add a middleware to the Gin app to record query parameters and request payload data.

We can add this to the docs for Go apps using OpenTelemetry.