### PR TITLE
Configure the OTP app option for Elixir Phoenix

### DIFF
--- a/elixir/phoenix/app/config/appsignal.exs
+++ b/elixir/phoenix/app/config/appsignal.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :appsignal, :config,
+  otp_app: :appsignal_phoenix_example,
+  env: Mix.env

--- a/elixir/phoenix/app/config/config.exs
+++ b/elixir/phoenix/app/config/config.exs
@@ -67,3 +67,5 @@ config :phoenix, :json_library, Jason
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"
+
+import_config "appsignal.exs"


### PR DESCRIPTION
This config seems to be missing. Add it.

[skip review]