### PR TITLE
Use custom Oban config prefix

### DIFF
--- a/elixir/plug-oban/app/config/config.exs
+++ b/elixir/plug-oban/app/config/config.exs
@@ -13,6 +13,7 @@ config :plug_oban,
 config :plug_oban, Oban,
   repo: PlugOban.Repo,
   plugins: [Oban.Plugins.Pruner],
-  queues: [default: 3, slow: 1]
+  queues: [default: 3, slow: 1],
+  prefix: "some_prefix"
 
 import_config "appsignal.exs"

--- a/elixir/plug-oban/app/priv/repo/migrations/20221128161801_add_oban_jobs_table.exs
+++ b/elixir/plug-oban/app/priv/repo/migrations/20221128161801_add_oban_jobs_table.exs
@@ -2,12 +2,12 @@ defmodule PlugOban.Repo.Migrations.AddObanJobsTable do
   use Ecto.Migration
 
   def up do
-    Oban.Migrations.up(version: 11)
+    Oban.Migrations.up(prefix: "some_prefix", version: 11)
   end
 
   # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if
   # necessary, regardless of which version we've migrated `up` to.
   def down do
-    Oban.Migrations.down(version: 1)
+    Oban.Migrations.down(prefix: "some_prefix", version: 1)
   end
 end


### PR DESCRIPTION
Use a custom Oban prefix to test support for the Oban config prefix in the Elixir integration.