### PR TITLE
Configure Sidekiq as Active Job adapter in Rails 8

### DIFF
--- a/ruby/rails8-sidekiq/app/config/application.rb
+++ b/ruby/rails8-sidekiq/app/config/application.rb
@@ -11,6 +11,8 @@ module ExampleApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
+    config.active_job.queue_adapter = :sidekiq
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.


### PR DESCRIPTION
For some reason the app wasn't configured to use Sidekiq for Active Job jobs, so it ran the Active Job jobs in the Rails thread.

Change the config so we can test Active Job with Sidekiq.

[skip review]