### PR TITLE
Add OpenTelemetry extension installation with pie

### DIFF
--- a/php/laravel-collector/commands/run
+++ b/php/laravel-collector/commands/run
@@ -2,8 +2,23 @@
 
 set -eu
 
-echo "Installing OpenTelemetry extension..."
-pecl install opentelemetry
+install_opentelemetry_extension_with_pecl() {
+  echo "Installing OpenTelemetry extension..."
+  pecl install opentelemetry
+}
+
+install_opentelemetry_extension_with_pie() {
+  echo "Installing PHP pie..."
+  curl -L https://github.com/php/pie/releases/latest/download/pie.phar -o /usr/local/bin/pie
+  chmod +x /usr/local/bin/pie
+
+  echo "Installing OpenTelemetry extension..."
+  pie install open-telemetry/ext-opentelemetry
+}
+
+# install_opentelemetry_extension_with_pecl
+install_opentelemetry_extension_with_pie
+
 # The path here matches the path that `php.ini` is written to in the Dockerfile
 echo "extension=opentelemetry.so" > /etc/php/8.4/cli/conf.d/99-sail.ini
 


### PR DESCRIPTION
Add pie as an alternative OpenTelemetry extension installation method.

I guess we want to be able to quickly switch between different options, so I've added the two tested options in functions one can uncomment to choose another method.