### PR TITLE
Use both `appsignal.env` and `appsignal_key.env` files

### DIFF
--- a/elixir/phoenix-collector/docker-compose.yml
+++ b/elixir/phoenix-collector/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=trace
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   app:
     build: .

--- a/go/beego-mod-otel/docker-compose.yml
+++ b/go/beego-mod-otel/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   appsignal:
     image: appsignal/agent:latest
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     environment:
       - APPSIGNAL_APP_NAME=go/beego-mod-otel

--- a/go/beego/docker-compose.yml
+++ b/go/beego/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   appsignal:
     image: appsignal/agent:latest
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     environment:
       - APPSIGNAL_APP_NAME=go/beego

--- a/go/go-gin-mysql-collector/docker-compose.yml
+++ b/go/go-gin-mysql-collector/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=trace
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   mysql:
     image: mysql
@@ -26,6 +27,7 @@ services:
       - APPSIGNAL_APP_NAME=go/go-gin-mysql-collector
       - APPSIGNAL_APP_ENV=development
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
       - ./app:/app

--- a/go/go-gin-mysql/docker-compose.yml
+++ b/go/go-gin-mysql/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   appsignal:
     image: appsignal/agent:latest
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     environment:
       - APPSIGNAL_APP_NAME=go/go-gin-mysql

--- a/go/gorilla-mux-mysql-redis-mongo-collector/docker-compose.yml
+++ b/go/gorilla-mux-mysql-redis-mongo-collector/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=trace
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   redis:
     image: redis
@@ -30,6 +31,7 @@ services:
       - APPSIGNAL_APP_NAME=go/gorilla-mux-mysql-redis-mongo-collector
       - APPSIGNAL_APP_ENV=development
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     volumes:
       - ./app:/app

--- a/go/gorilla-mux-mysql-redis-mongo/docker-compose.yml
+++ b/go/gorilla-mux-mysql-redis-mongo/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   appsignal:
     image: appsignal/agent:latest
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     environment:
       - APPSIGNAL_APP_NAME=go/gorilla-mux-mysql-redis-mongo

--- a/java/spring-agent-collector/docker-compose.yml
+++ b/java/spring-agent-collector/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       APPSIGNAL_APP_ENV: development
       SERVER_PORT: "4001"
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     ports:
       - "4001:4001"
@@ -19,6 +20,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=trace
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   tests:
     image: server-tests

--- a/java/spring-native-collector/docker-compose.yml
+++ b/java/spring-native-collector/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       APPSIGNAL_APP_ENV: development
       SERVER_PORT: "4001"
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     ports:
       - "4001:4001"
@@ -20,6 +21,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=trace
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   tests:
     image: server-tests

--- a/javascript/react-vite-collector/docker-compose.yml
+++ b/javascript/react-vite-collector/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=trace
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   app:
     build:

--- a/nodejs/express-postgres-collector/docker-compose.yml
+++ b/nodejs/express-postgres-collector/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=debug
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   app:
     build: .

--- a/php/laravel-collector/docker-compose.yml
+++ b/php/laravel-collector/docker-compose.yml
@@ -35,6 +35,7 @@ services:
             APPSIGNAL_APP_NAME: php/laravel-collector
             APPSIGNAL_APP_ENV: development
         env_file:
+            - ../../appsignal.env
             - ../../appsignal_key.env
         volumes:
             - './app:/var/www/html'
@@ -65,6 +66,7 @@ services:
         environment:
             - APPSIGNAL_LOG_LEVEL=trace
         env_file:
+            - ../../appsignal.env
             - ../../appsignal_key.env
     tests:
       build: ../../support/server-tests

--- a/python/django5-celery-collector/docker-compose.yml
+++ b/python/django5-celery-collector/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=debug
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   app:
     build: .

--- a/ruby/rails7-postgres/docker-compose.yml
+++ b/ruby/rails7-postgres/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - VECTOR_LOG=debug
     env_file:
       - postgres.env
+      - ../../appsignal.env
       - ../../appsignal_key.env
     depends_on:
       - postgres

--- a/ruby/rails8-sidekiq-collector/docker-compose.yml
+++ b/ruby/rails8-sidekiq-collector/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - APPSIGNAL_LOG_LEVEL=debug
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
   app:
     build: .

--- a/standalone/nginx/docker-compose.yml
+++ b/standalone/nginx/docker-compose.yml
@@ -17,4 +17,5 @@ services:
       - APPSIGNAL_APP_ENV=development
       - APPSIGNAL_LOG_LEVEL=trace
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env

--- a/vector/mongodb/docker-compose.yml
+++ b/vector/mongodb/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - MONGODB_URL_2=mongodb://mongo-2:27017/
       - MONGODB_URL_3=mongodb://mongo-3:27017/
     env_file:
+      - ../../appsignal.env
       - ../../appsignal_key.env
     depends_on:
       - mongo-1


### PR DESCRIPTION
This avoids confusion when, for example, the key is set in the `appsignal_key.env` file, but the endpoint is set on the `appsignal.env` file.