### PR TITLE
Add AppSignal metadata to Java app

### DIFF
--- a/java/spring-agent-collector/app/build.gradle.kts
+++ b/java/spring-agent-collector/app/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("com.h2database:h2")
     implementation("io.opentelemetry:opentelemetry-api")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
 }
 
 spotless {

--- a/java/spring-agent-collector/app/build.gradle.kts
+++ b/java/spring-agent-collector/app/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("com.h2database:h2")
+    implementation("io.opentelemetry:opentelemetry-api")
 }
 
 spotless {

--- a/java/spring-agent-collector/app/src/main/java/io/opentelemetry/example/graal/Controller.java
+++ b/java/spring-agent-collector/app/src/main/java/io/opentelemetry/example/graal/Controller.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import java.util.HashMap;
 import java.util.Map;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.StructuredDataMessage;
@@ -36,6 +37,40 @@ public class Controller {
     span.setAttribute(AttributeKey.longArrayKey("appsignal.tag.my_tag_int_array"), Arrays.asList(1234L, 5678L));
     span.setAttribute("appsignal.tag.my_tag_int64", 1234);
     span.setAttribute(AttributeKey.longArrayKey("appsignal.tag.my_tag_int64_array"), Arrays.asList(1234L, 5678L));
+
+    // Create nested HashMap structure and serialize to JSON
+    Map<String, Object> queryParams = new HashMap<>();
+    queryParams.put("param1", "value1");
+    queryParams.put("param2", "value2");
+
+    Map<String, String> nested = new HashMap<>();
+    nested.put("param3", "value3");
+    nested.put("param4", "value4");
+    queryParams.put("nested", nested);
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      String jsonString = mapper.writeValueAsString(queryParams);
+      span.setAttribute("appsignal.request.query_parameters", jsonString);
+      span.setAttribute("appsignal.request.payload", jsonString);
+      span.setAttribute("appsignal.request.session_data", jsonString);
+      span.setAttribute("appsignal.function.parameters", jsonString);
+    } catch (Exception e) {
+      Logger logger = LogManager.getLogger(Controller.class);
+      logger.error("Failed to serialize query parameters to JSON", e);
+    }
+
+    // Set single header values
+    span.setAttribute("http.request.header.content-length", 123);
+    span.setAttribute("http.request.header.request-method", "GET");
+    span.setAttribute("http.request.header.path-info", "/some-path");
+    span.setAttribute("http.request.header.content-type", "application/json");
+
+    // Set header with multiple values (array)
+    span.setAttribute(
+      AttributeKey.stringArrayKey("http.request.header.custom-header"),
+      Arrays.asList("value1", "value2")
+    );
   }
 
   @GetMapping("/slow")

--- a/java/spring-agent-collector/app/src/main/java/io/opentelemetry/example/graal/Controller.java
+++ b/java/spring-agent-collector/app/src/main/java/io/opentelemetry/example/graal/Controller.java
@@ -13,21 +13,48 @@ import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.apache.logging.log4j.ThreadContext;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+
+import java.util.Arrays;
+
 @RestController
 public class Controller {
+
+  private void setSpanAttributes() {
+    Span span = Span.current();
+    span.setAttribute("appsignal.tag.user_id", 123);
+    span.setAttribute("appsignal.tag.my_tag_string", "tag value");
+    span.setAttribute(AttributeKey.stringArrayKey("appsignal.tag.my_tag_string_array"), Arrays.asList("abc", "def"));
+    span.setAttribute("appsignal.tag.my_tag_bool_true", true);
+    span.setAttribute("appsignal.tag.my_tag_bool_false", false);
+    span.setAttribute(AttributeKey.booleanArrayKey("appsignal.tag.my_tag_bool_array"), Arrays.asList(true, false));
+    span.setAttribute("appsignal.tag.my_tag_float64", 12.34);
+    span.setAttribute(AttributeKey.doubleArrayKey("appsignal.tag.my_tag_float64_array"), Arrays.asList(12.34, 56.78));
+    span.setAttribute("appsignal.tag.my_tag_int", 1234);
+    span.setAttribute(AttributeKey.longArrayKey("appsignal.tag.my_tag_int_array"), Arrays.asList(1234L, 5678L));
+    span.setAttribute("appsignal.tag.my_tag_int64", 1234);
+    span.setAttribute(AttributeKey.longArrayKey("appsignal.tag.my_tag_int64_array"), Arrays.asList(1234L, 5678L));
+  }
+
   @GetMapping("/slow")
   public String slow() throws InterruptedException {
+    setSpanAttributes();
     Thread.sleep(3000);
     return "Well, that took forever!";
   }
 
   @GetMapping("/error")
   public String error() {
+    setSpanAttributes();
     throw new RuntimeException("Whoops!");
   }
 
   @GetMapping("/logs")
   public String logs() throws InterruptedException {
+    setSpanAttributes();
+
     for (int i = 0; i < 10; i++) {
       // Set ThreadContext key-value:
       ThreadContext.put("something", "threadcontext");
@@ -69,6 +96,8 @@ public class Controller {
 
   @GetMapping("/")
   public String root() {
+    setSpanAttributes();
+
     return "<html>" +
            "<body>" +
            "<h1>Java + Spring Boot test setup:</h1>" +

--- a/java/spring-agent-collector/commands/run
+++ b/java/spring-agent-collector/commands/run
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -eu
 
 cd /app
 
@@ -16,6 +18,10 @@ else
     fi
 fi
 
+function encode() {
+  echo -n "$@" | sed 's/,/%2C/g'
+}
+
 # Build resource attributes string
 # (these could be in `agent.properties` but are here
 # so that environment variables can be interpolated in them)
@@ -25,6 +31,7 @@ appsignal.config.push_api_key=$APPSIGNAL_PUSH_API_KEY,\
 appsignal.config.revision=abcd123,\
 appsignal.config.language_integration=java,\
 appsignal.config.app_path=$PWD,\
+appsignal.config.request_headers=$(encode "request-method,path-info,content-type,custom-header"),\
 host.name=${HOSTNAME:-$(hostname)}"
 
 JAVA_OPTS="-javaagent:/app/$AGENT_JAR \


### PR DESCRIPTION
## Add tags to Java app requests

Test that tags work for the Java OpenTelemetry app.

## Add AppSignal metadata to Java app

Add the different types of metadata to the Java example app so we can test if the data is coming through okay.
