### PR TITLE
Add Semantic logger code for Rails app

### DIFF
--- a/ruby/rails8-sidekiq/app/Gemfile
+++ b/ruby/rails8-sidekiq/app/Gemfile
@@ -65,3 +65,7 @@ end
 gem "sidekiq", "8.0.0"
 gem "appsignal", :path => "/integration"
 gem "ownership"
+
+# Enable these lines when testing semantic logger
+# gem "rails_semantic_logger", "4.17.0"
+# gem "semantic_logger", "4.16.1"

--- a/ruby/rails8-sidekiq/app/app/controllers/examples_controller.rb
+++ b/ruby/rails8-sidekiq/app/app/controllers/examples_controller.rb
@@ -4,6 +4,14 @@ class ExamplesController < ApplicationController
   owner :examples
 
   def index
+    Rails.logger.info(
+      "Test log message",
+      abc: "def",
+      # Attribute value with quotes in them
+      params: { "foo" => "bar", "abc" => "def" },
+      # This tag should also show up
+      final_tag: "test"
+    )
     session[:user_id] = :some_user_id_123
     session[:menu] = { :state => :open, :view => :full }
   end

--- a/ruby/rails8-sidekiq/app/config/initializers/logging.rb
+++ b/ruby/rails8-sidekiq/app/config/initializers/logging.rb
@@ -1,5 +1,30 @@
-Rails.application.config.log_tags = [:request_id]
+# Prepend all log lines with the following tags.
+Rails.application.config.log_tags = {
+  request_id: :request_id,
+  ip: :remote_ip,
+  referer: ->(request) { request.headers["Referer"] }
+}
 
 appsignal_logger = Appsignal::Logger.new("rails")
 appsignal_logger.broadcast_to(Rails.logger)
 Rails.logger = ActiveSupport::TaggedLogging.new(appsignal_logger)
+
+# Semantic logger example
+# Disable the Rails.logger config above this when you enable the config below
+# log_filter = ->(log) { log.payload&.[](:path) != "/up".freeze }
+# # if ENV["RAILS_LOG_TO_STDOUT"].present?
+#   $stdout.sync = true
+#   Rails.application.config.rails_semantic_logger.add_file_appender = false
+#   Rails.application.config.rails_semantic_logger.semantic = true
+#   Rails.application.config.rails_semantic_logger.format = :logfmt
+#   Rails.application.config.semantic_logger.add_appender(io: $stdout, formatter: :logfmt, filter: log_filter)
+# # end
+#
+# appsignal_logger = Appsignal::Logger.new("rails", format: Appsignal::Logger::LOGFMT)
+# SemanticLogger.add_appender(logger: appsignal_logger, formatter: :logfmt, filter: log_filter)
+#
+# # Log to STDOUT by default
+# Rails.application.config.logger = ActiveSupport::Logger.new(STDOUT)
+#   .tap { |logger| logger.formatter = ::Logger::Formatter.new }
+#   .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+#


### PR DESCRIPTION
I've not enabled it by default because we don't need it. But it's good to have some example code in the app ready to go.

[skip review]