### PR TITLE
Configure laravel with code from `.env`

### DIFF
--- a/php/laravel-collector/app/.env.example
+++ b/php/laravel-collector/app/.env.example
@@ -1,6 +1,20 @@
+# The `commands/run` file interpolates this file with `sed` 
+# to create the `.env` file used by the application.
+
+# This is due to some maddening behaviour by Laravel and/or
+# the `phpdotenv` library, where environment variables that are
+# both set in the `.env` file and in the environment
+# are not picked up by the application, and referring to them
+# via `$_ENV` in a provider causes Composer to crash when generating
+# the optimised autoload files.
+
+# This is here to test that the OpenTelemetry instrumentation configured
+# at `instrumentation.php` can correctly pick up environment variables
+TEST_VALUE="from-env"
+
 APP_NAME=Laravel
 APP_ENV=local
-APP_KEY=
+APP_KEY=J0TeTiVkAlJ2eUndVMKCi5EGjNPittlM
 APP_DEBUG=true
 APP_URL=http://localhost
 
@@ -20,12 +34,12 @@ LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
-DB_CONNECTION=sqlite
-# DB_HOST=127.0.0.1
-# DB_PORT=3306
-# DB_DATABASE=laravel
-# DB_USERNAME=root
-# DB_PASSWORD=
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=laravel
+DB_PASSWORD=password
 
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
@@ -63,3 +77,13 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+WWWUSER=1000
+LARAVEL_SAIL=1
+XDEBUG_MODE=off
+XDEBUG_CONFIG=client_host=host.docker.internal
+IGNITION_LOCAL_SITES_PATH=${PWD}/app
+
+# The `commands/run` file interpolates this file with `sed`
+# to create the `.env` file used by the application.
+# The environment variables will be added below.

--- a/php/laravel-collector/app/bootstrap/app.php
+++ b/php/laravel-collector/app/bootstrap/app.php
@@ -3,8 +3,9 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 
-return Application::configure(basePath: dirname(__DIR__))
+$app = Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
@@ -16,3 +17,9 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withExceptions(function (Exceptions $exceptions) {
         //
     })->create();
+
+(new LoadEnvironmentVariables())->bootstrap($app);
+
+require(base_path('bootstrap/instrumentation.php'));
+
+return $app;

--- a/php/laravel-collector/app/bootstrap/instrumentation.php
+++ b/php/laravel-collector/app/bootstrap/instrumentation.php
@@ -1,0 +1,81 @@
+<?php
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\EventLogger;
+use OpenTelemetry\API\Logs\LogRecord;
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\Contrib\Otlp\LogsExporter;
+use OpenTelemetry\Contrib\Otlp\MetricExporter;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\Processor\SimpleLogRecordProcessor;
+use OpenTelemetry\SDK\Metrics\MeterProvider;
+use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SDK\Sdk;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory;
+
+$resource = ResourceInfoFactory::emptyResource()->merge(ResourceInfo::create(Attributes::create([
+  'service.name' => "Laravel",
+  'appsignal.config.name' => $_ENV['APPSIGNAL_APP_NAME'],
+  'appsignal.config.environment' => $_ENV['APPSIGNAL_APP_ENV'],
+  'appsignal.config.push_api_key' => $_ENV['APPSIGNAL_PUSH_API_KEY'],
+  'appsignal.config.revision' => 'abcd123',
+  'appsignal.config.language_integration' => 'php',
+  'appsignal.config.app_path' => dirname(__DIR__),
+  'host.name' => gethostname(),
+  'test_value' => $_ENV['TEST_VALUE'] ?? 'default_value',
+])));
+
+$collector = 'http://appsignal-collector:8099';
+
+
+$spanExporter = new SpanExporter(
+    (new OtlpHttpTransportFactory())->create("$collector/v1/traces", 'application/x-protobuf')
+);
+
+$logExporter = new LogsExporter(
+    (new OtlpHttpTransportFactory())->create("$collector/v1/logs", 'application/x-protobuf')
+);
+
+$reader = new ExportingReader(
+    new MetricExporter(
+        (new OtlpHttpTransportFactory())->create("$collector/v1/metrics", 'application/x-protobuf')
+    )
+);
+
+$meterProvider = MeterProvider::builder()
+    ->setResource($resource)
+    ->addReader($reader)
+    ->build();
+
+$tracerProvider = TracerProvider::builder()
+    ->addSpanProcessor(
+        new SimpleSpanProcessor($spanExporter)
+    )
+    ->setResource($resource)
+    ->setSampler(new ParentBased(new AlwaysOnSampler()))
+    ->build();
+
+$loggerProvider = LoggerProvider::builder()
+    ->setResource($resource)
+    ->addLogRecordProcessor(
+        new SimpleLogRecordProcessor($logExporter)
+    )
+    ->build();
+
+Sdk::builder()
+    ->setTracerProvider($tracerProvider)
+    ->setMeterProvider($meterProvider)
+    ->setLoggerProvider($loggerProvider)
+    ->setPropagator(TraceContextPropagator::getInstance())
+    ->setAutoShutdown(true)
+    ->buildAndRegisterGlobal();

--- a/php/laravel-collector/commands/run
+++ b/php/laravel-collector/commands/run
@@ -5,6 +5,9 @@ set -eu
 install_opentelemetry_extension_with_pecl() {
   echo "Installing OpenTelemetry extension..."
   pecl install opentelemetry
+
+  # The path here matches the path that `php.ini` is written to in the Dockerfile
+  echo "extension=opentelemetry.so" > /etc/php/8.4/cli/conf.d/99-sail.ini
 }
 
 install_opentelemetry_extension_with_pie() {
@@ -14,6 +17,9 @@ install_opentelemetry_extension_with_pie() {
 
   echo "Installing OpenTelemetry extension..."
   pie install open-telemetry/ext-opentelemetry
+
+  # No need to add the extension to the php.ini file,
+  # as `pie` does this automatically
 }
 
 install_opentelemetry_extension_with_pickle() {
@@ -23,35 +29,38 @@ install_opentelemetry_extension_with_pickle() {
 
   echo "Installing OpenTelemetry extension..."
   pickle install opentelemetry
+
+  # The path here matches the path that `php.ini` is written to in the Dockerfile
+  echo "extension=opentelemetry.so" > /etc/php/8.4/cli/conf.d/99-sail.ini
 }
 
 # install_opentelemetry_extension_with_pecl
-# install_opentelemetry_extension_with_pie
-install_opentelemetry_extension_with_pickle
-
-# The path here matches the path that `php.ini` is written to in the Dockerfile
-echo "extension=opentelemetry.so" > /etc/php/8.4/cli/conf.d/99-sail.ini
+install_opentelemetry_extension_with_pie
+# install_opentelemetry_extension_with_pickle
 
 cd /var/www/html
 
 # Fix file permissions on CI
 chmod -R 777 /var/www/html
 
-function encode() {
-  echo -n "$@" | sed 's/,/%2C/g'
-}
+# Fix environment variable file
+echo "Creating .env file..."
 
-export OTEL_RESOURCE_ATTRIBUTES="appsignal.config.name=$APPSIGNAL_APP_NAME,\
-appsignal.config.environment=$APPSIGNAL_APP_ENV,\
-appsignal.config.push_api_key=$APPSIGNAL_PUSH_API_KEY,\
-appsignal.config.revision=abcd123,\
-appsignal.config.language_integration=php,\
-appsignal.config.app_path=$PWD,\
-foo.bar=$(encode "123,456"),\
-empty.string=,\
-baz.qux=%48%65%6C%6C%6F%20%77%6F%72%6C%64%21,\
-white.space=Yes please,\
-host.name=${HOSTNAME:-$(hostname)}"
+rm .env || true
+
+cp .env.example .env
+
+echo "APPSIGNAL_APP_NAME=${APPSIGNAL_APP_NAME}" >> .env
+echo "APPSIGNAL_APP_ENV=${APPSIGNAL_APP_ENV}" >> .env
+echo "APPSIGNAL_PUSH_API_KEY=${APPSIGNAL_PUSH_API_KEY}" >> .env
+
+# It is necessary to unexport these environment variables.
+# If an environment variable is both exported and set in the `.env` file,
+# the variable will be unset in `$_ENV` when the Composer autoloader files
+# are generated.
+export -n APPSIGNAL_APP_NAME
+export -n APPSIGNAL_APP_ENV
+export -n APPSIGNAL_PUSH_API_KEY
 
 echo "Installing dependencies..."
 composer install
@@ -66,4 +75,12 @@ done
 echo "Database started!"
 /var/www/html/artisan migrate:fresh
 
+echo "Cleaning caches..."
+php artisan config:clear
+php artisan route:clear
+php artisan view:clear
+php artisan event:clear
+php artisan cache:clear
+
+echo "Starting the application..."
 start-container

--- a/php/laravel-collector/docker-compose.yml
+++ b/php/laravel-collector/docker-compose.yml
@@ -12,26 +12,15 @@ services:
             - '4001:4001'
             - '5173:5173'
         environment:
-            WWWUSER: '1000'
-            LARAVEL_SAIL: 1
-            XDEBUG_MODE: 'off'
-            XDEBUG_CONFIG: 'client_host=host.docker.internal'
-            IGNITION_LOCAL_SITES_PATH: '${PWD}/app'
-            DB_CONNECTION: mysql
+            # These environment variables are used by /commands/run
+            # to wait for the database to be ready.
             DB_HOST: mysql
             DB_PASSWORD: password
             DB_USERNAME: laravel
-            APP_DEBUG: 'true'
-            APP_ENV: local
-            APP_KEY: 'J0TeTiVkAlJ2eUndVMKCi5EGjNPittlM'
-            OTEL_PHP_AUTOLOAD_ENABLED: 'true'
-            OTEL_SERVICE_NAME: Laravel
-            OTEL_TRACES_EXPORTER: otlp
-            OTEL_METRICS_EXPORTER: otlp
-            OTEL_LOGS_EXPORTER: otlp
-            OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-            OTEL_EXPORTER_OTLP_ENDPOINT: http://appsignal-collector:8099
-            OTEL_PROPAGATORS: baggage,tracecontext
+            # All other environment variables for the Laravel
+            # application are set in the `.env` file, either hardcoded,
+            # or by setting then in `/commands/run` from the ones
+            # defined here and in `env_file`:
             APPSIGNAL_APP_NAME: php/laravel-collector
             APPSIGNAL_APP_ENV: development
         env_file:


### PR DESCRIPTION
In `bootstrap/app.php`, we manually call the `LoadEnvironmentVariables` bootstrapper on the app instance, then initialise the OpenTelemetry instrumentation, then return the app. This makes it possible to configure AppSignal with the same environment variables that the Laravel application will use, while also initialising OpenTelemetry early enough that Laravel routes are instrumented.

The instrumentation file itself is generic and _should_ work with any other PHP framework, though this of course hasn't been tested. It may be worth building a test setup with Symfony, or if not, one using Slim, and optionally Dotenv.