### PR TITLE
Add IO instrumentation to PHP Laravel app

### DIFF
--- a/php/laravel-collector/app/composer.json
+++ b/php/laravel-collector/app/composer.json
@@ -14,7 +14,8 @@
         "laravel/tinker": "^2.10.1",
         "open-telemetry/sdk": "^1.2.2",
         "open-telemetry/exporter-otlp": "^1.2.0",
-        "open-telemetry/opentelemetry-auto-laravel": "^1.0.1"
+        "open-telemetry/opentelemetry-auto-laravel": "^1.0.1",
+        "open-telemetry/opentelemetry-auto-io": "^0.0.14"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/php/laravel-collector/app/composer.lock
+++ b/php/laravel-collector/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d1a40b9162a46deb511e19617e6341f",
+    "content-hash": "d24f3158df9843c1007a4e368589da74",
     "packages": [
         {
             "name": "brick/math",
@@ -2954,6 +2954,65 @@
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
             "time": "2025-01-15T23:07:07+00:00"
+        },
+        {
+            "name": "open-telemetry/opentelemetry-auto-io",
+            "version": "0.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/contrib-auto-io.git",
+                "reference": "4808e34acb8bbdb30a9d50377a80d2ac6bc964b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/contrib-auto-io/zipball/4808e34acb8bbdb30a9d50377a80d2ac6bc964b4",
+                "reference": "4808e34acb8bbdb30a9d50377a80d2ac6bc964b4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-opentelemetry": "*",
+                "open-telemetry/api": "^1.0",
+                "open-telemetry/sem-conv": "^1.32",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "open-telemetry/sdk": "^1.0",
+                "phan/phan": "^5.0",
+                "php-http/mock-client": "*",
+                "phpstan/phpstan": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "vimeo/psalm": "6.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "_register.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\Contrib\\Instrumentation\\IO\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "OpenTelemetry auto-instrumentation for IO",
+            "homepage": "https://opentelemetry.io/docs/php",
+            "keywords": [
+                "instrumentation",
+                "io",
+                "open-telemetry",
+                "opentelemetry",
+                "otel",
+                "tracing"
+            ],
+            "support": {
+                "source": "https://github.com/opentelemetry-php/contrib-auto-io/tree/0.0.14"
+            },
+            "time": "2025-05-14T00:19:47+00:00"
         },
         {
             "name": "open-telemetry/opentelemetry-auto-laravel",

--- a/php/laravel-collector/app/resources/views/welcome.blade.php
+++ b/php/laravel-collector/app/resources/views/welcome.blade.php
@@ -57,6 +57,7 @@
                     <li><a href="/error" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/error</a></li>
                     <li><a href="/logs" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/logs</a></li>
                     <li><a href="/queue" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/queue</a></li>
+                    <li><a href="/io" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/io</a></li>
                 </ul>
             </div>
             <main class="flex max-w-[335px] w-full flex-col-reverse lg:max-w-4xl lg:flex-row">

--- a/php/laravel-collector/app/resources/views/welcome.blade.php
+++ b/php/laravel-collector/app/resources/views/welcome.blade.php
@@ -50,6 +50,15 @@
             @endif
         </header>
         <div class="flex items-center justify-center w-full transition-opacity opacity-100 duration-750 lg:grow starting:opacity-0">
+            <div class="mb-6 p-6 bg-white dark:bg-[#161615] rounded-lg shadow-md">
+                <h2 class="text-lg font-semibold mb-4 text-[#1B1B18] dark:text-[#EDEDEC]">PHP + Laravel test setup:</h2>
+                <ul class="space-y-2">
+                    <li><a href="/slow" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/slow</a></li>
+                    <li><a href="/error" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/error</a></li>
+                    <li><a href="/logs" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/logs</a></li>
+                    <li><a href="/queue" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/queue</a></li>
+                </ul>
+            </div>
             <main class="flex max-w-[335px] w-full flex-col-reverse lg:max-w-4xl lg:flex-row">
                 <div class="text-[13px] leading-[20px] flex-1 p-6 pb-12 lg:p-20 bg-white dark:bg-[#161615] dark:text-[#EDEDEC] shadow-[inset_0px_0px_0px_1px_rgba(26,26,0,0.16)] dark:shadow-[inset_0px_0px_0px_1px_#fffaed2d] rounded-bl-lg rounded-br-lg lg:rounded-tl-lg lg:rounded-br-none">
                     <h1 class="mb-1 font-medium">Let's get started</h1>


### PR DESCRIPTION
## Add routes to PHP example app view

Make it easier to go to the different test routes.

## Add IO instrumentation to PHP Laravel app

Add an /io route with a couple file operations. Add the open-telemetry/opentelemetry-auto-io instrumentation package to instrument file operations

I don't see `file_put_contents` reported, even though the instrumentation package readme says it should 🤷‍♂️ https://github.com/opentelemetry-php/contrib-auto-io
