### PR TITLE
Go app configuration improvements

### DIFF
--- a/go/go-gin-mysql-collector/app/main.go
+++ b/go/go-gin-mysql-collector/app/main.go
@@ -84,12 +84,12 @@ func initInstrumentation() func() {
 	)
 	traceExporter, err := otlptrace.New(context.Background(), traceClient)
 	if err != nil {
-		log.Fatal("creating OTLP trace exporter: %w")
+		log.Fatalf("creating OTLP trace exporter: %v", err)
 	}
 
 	consoleExporter, err := newConsoleExporter()
 	if err != nil {
-		log.Fatal("creating OTLP console exporter: %w")
+		log.Fatalf("creating OTLP console exporter: %v", err)
 	}
 
 	tracerProvider := sdktrace.NewTracerProvider(
@@ -107,7 +107,7 @@ func initInstrumentation() func() {
 		otlpmetrichttp.WithEndpoint("appsignal-collector:8099"),
 	)
 	if err != nil {
-		log.Fatal("creating OTLP metric exporter: %w")
+		log.Fatalf("creating OTLP metric exporter: %v", err)
 	}
 
 	meterProvider := sdkmetric.NewMeterProvider(
@@ -123,7 +123,7 @@ func initInstrumentation() func() {
 		otlploghttp.WithEndpoint("appsignal-collector:8099"),
 	)
 	if err != nil {
-		log.Fatal("creating OTLP log exporter: %w")
+		log.Fatalf("creating OTLP log exporter: %v", err)
 	}
 
 	loggerProvider := sdklog.NewLoggerProvider(

--- a/go/go-gin-mysql-collector/app/main.go
+++ b/go/go-gin-mysql-collector/app/main.go
@@ -18,28 +18,31 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 
-	"github.com/XSAM/otelsql"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+	// From our installer
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
-	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
-	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/metric"
-	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+
+	// For custom instrumentation
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 
-	"go.opentelemetry.io/otel/log/global"
-
+	// Additional instrumentation
+	"github.com/XSAM/otelsql"
 	"go.opentelemetry.io/contrib/bridges/otelslog"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
 var tracer = otel.Tracer("opentelemetry-go-gin")

--- a/go/go-gin-mysql-collector/app/main.go
+++ b/go/go-gin-mysql-collector/app/main.go
@@ -132,13 +132,14 @@ func initInstrumentation() func() {
 	global.SetLoggerProvider(loggerProvider)
 
 	return func() {
-		if err := tracerProvider.Shutdown(context.Background()); err != nil {
+		ctx := context.Background()
+		if err := tracerProvider.Shutdown(ctx); err != nil {
 			log.Println("Error shutting down tracer provider:", err)
 		}
-		if err := meterProvider.Shutdown(context.Background()); err != nil {
+		if err := meterProvider.Shutdown(ctx); err != nil {
 			log.Println("Error shutting down meter provider:", err)
 		}
-		if err := loggerProvider.Shutdown(context.Background()); err != nil {
+		if err := loggerProvider.Shutdown(ctx); err != nil {
 			log.Println("Error shutting down logger provider:", err)
 		}
 	}

--- a/go/go-gin-mysql-collector/app/main.go
+++ b/go/go-gin-mysql-collector/app/main.go
@@ -55,7 +55,7 @@ func newConsoleExporter() (sdktrace.SpanExporter, error) {
 	)
 }
 
-func initInstrumentation() func() {
+func initOpenTelemetry() func() {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "unknown"
@@ -217,7 +217,7 @@ func ReadFile(file string) error {
 }
 
 func main() {
-	cleanup := initInstrumentation()
+	cleanup := initOpenTelemetry()
 	defer cleanup()
 
 	db, err := otelsql.Open(


### PR DESCRIPTION
## Assign context to variable in Go defer example

Don't get the context three times, but once and assign it to a variable.

## Use single Go resource import

We had a resource and sdkresource import. Use just one.

## Organize Go imports

Make clear what's from our installer copy-pasted and what custom things we added for the test app, so it's easier to compare in the future when updating our instructions.

## Fix Go error logging

It was pointed out to us that our use of log.Fatal calls was not including the actual error.
