### PR TITLE
Add example to show PHP stacktraces

### DIFF
--- a/php/laravel-collector/app/app/Http/Controllers/BacktraceController.php
+++ b/php/laravel-collector/app/app/Http/Controllers/BacktraceController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Exception;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\StatusCode;
+
+class BacktraceController extends Controller
+{
+    public function backtrace()
+    {
+        try {
+            $this->methodA();
+        } catch (Exception $e) {
+            $span = Span::getCurrent();
+            $span->recordException($e);
+            $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+
+            return response()->view('backtrace', [
+                'error' => $e->getMessage(),
+                'backtrace' => $e->getTraceAsString()
+            ], 500);
+        }
+    }
+
+    private function methodA()
+    {
+        usleep(50000); // 50ms delay
+        return $this->methodB();
+    }
+
+    private function methodB()
+    {
+        usleep(30000); // 30ms delay
+        return $this->methodC();
+    }
+
+    private function methodC()
+    {
+        usleep(20000); // 20ms delay
+        return $this->methodD();
+    }
+
+    private function methodD()
+    {
+        usleep(10000); // 10ms delay
+        return $this->methodE();
+    }
+
+    private function methodE()
+    {
+        usleep(5000); // 5ms delay
+        return $this->methodF();
+    }
+
+    private function methodF()
+    {
+        return $this->throwError();
+    }
+
+    private function throwError()
+    {
+        throw new Exception('Deep stack trace error from methodF -> throwError');
+    }
+}

--- a/php/laravel-collector/app/resources/views/backtrace.blade.php
+++ b/php/laravel-collector/app/resources/views/backtrace.blade.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PHP Backtrace Test</title>
+</head>
+<body>
+    <h1>PHP Backtrace Test</h1>
+
+    <p><strong>Error:</strong> {{ $error }}</p>
+
+    <p><strong>Note:</strong> This error was intentionally thrown and caught to demonstrate PHP backtrace functionality.
+    The error flows through multiple methods (A → B → C → D → E → F → throwError) to create an extensive call stack.
+    The error has been reported to AppSignal via OpenTelemetry.</p>
+
+    <h2>PHP Backtrace (via $e->getTraceAsString())</h2>
+    <pre>{{ $backtrace }}</pre>
+
+    <a href="/">← Back to Home</a>
+</body>
+</html>

--- a/php/laravel-collector/app/resources/views/welcome.blade.php
+++ b/php/laravel-collector/app/resources/views/welcome.blade.php
@@ -55,6 +55,7 @@
                 <ul class="space-y-2">
                     <li><a href="/slow" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/slow</a></li>
                     <li><a href="/error" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/error</a></li>
+                    <li><a href="/backtrace" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/backtrace</a></li>
                     <li><a href="/logs" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/logs</a></li>
                     <li><a href="/queue" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/queue</a></li>
                     <li><a href="/io" class="text-[#f53003] dark:text-[#FF4433] underline hover:text-[#d42a00]">/io</a></li>

--- a/php/laravel-collector/app/routes/web.php
+++ b/php/laravel-collector/app/routes/web.php
@@ -96,3 +96,5 @@ Route::get('/io', function () {
         'results' => $results
     ]);
 });
+
+Route::get('/backtrace', [App\Http\Controllers\BacktraceController::class, 'backtrace']);


### PR DESCRIPTION
Show plain PHP stacktraces, not the OpenTelemetry format so we can compare. Add an extra endpoint so we see a bit more complex stacktrace.

[skip review]