### PR TITLE
Fix apps using Debian buster by updating Debian

### DIFF
--- a/go/beego/Dockerfile
+++ b/go/beego/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster
+FROM golang:1.18-bullseye
 
 ENV REFRESHED_AT=2023-02-23
 

--- a/python/django4-celery/Dockerfile
+++ b/python/django4-celery/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-02-08

--- a/python/django5-celery-collector/Dockerfile
+++ b/python/django5-celery-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-02-08

--- a/python/django5-celery/Dockerfile
+++ b/python/django5-celery/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-02-08

--- a/python/fastapi/Dockerfile
+++ b/python/fastapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-05-23

--- a/python/flask/Dockerfile
+++ b/python/flask/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-05-23

--- a/python/starlette/Dockerfile
+++ b/python/starlette/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 # Update this if the docker image changes
 ENV REFRESHED_AT=2023-05-23


### PR DESCRIPTION
The buster update server is returning errors on update. Update Debian to the next version to fix it.

[skip review]