### PR TITLE
Update Bundler in Hanami 2 app to fix CI

### DIFF
--- a/ruby/hanami2-postgres/app/Gemfile.lock
+++ b/ruby/hanami2-postgres/app/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: /integration
   specs:
-    appsignal (4.1.2)
+    appsignal (4.5.17)
       logger
-      rack
+      rack (>= 2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -324,4 +324,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.5.22
+   2.7.0

--- a/ruby/hanami2-postgres/app/config/db/structure.sql
+++ b/ruby/hanami2-postgres/app/config/db/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 16.0 (Debian 16.0-1.pgdg120+1)
--- Dumped by pg_dump version 16.4 (Debian 16.4-1.pgdg120+2)
+-- Dumped by pg_dump version 16.9 (Debian 16.9-1.pgdg120+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
It's broken because of the error message below. Fix it by updating bundler.

```
/usr/local/lib/ruby/site_ruby/3.3.0/rubygems.rb:312:in `load': cannot load such file -- /usr/local/bundle/gems/bundler-2.5.22/lib/gems/bundler-2.5.22/exe/bundle (LoadError)
  from /usr/local/lib/ruby/site_ruby/3.3.0/rubygems.rb:312:in `activate_and_load_bin_path'
  from /usr/local/bundle/bin/bundle:25:in `<main>'
```

[skip review]