### PR TITLE
Add logging and metrics for Go, Java and PHP

### DIFF
--- a/go/go-gin-mysql-collector/app/index.html
+++ b/go/go-gin-mysql-collector/app/index.html
@@ -4,5 +4,5 @@
   <li><a href="/error"><kbd>/error</kbd></a> → Request with an error status code</li>
   <li><a href="/mysql-query"><kbd>/mysql-query</kbd></a> → Request that performs a MySQL query</li>
   <li><a href="/metrics"><kbd>/metrics</kbd></a> → Request that sends custom metrics</li>
-  <li><a href="/logs"><kbd>/error</kbd></a> → Request that sends custom logs</li>
+  <li><a href="/logs"><kbd>/logs</kbd></a> → Request that sends custom logs</li>
 </ul>

--- a/go/go-gin-mysql-collector/app/main.go
+++ b/go/go-gin-mysql-collector/app/main.go
@@ -390,7 +390,7 @@ func main() {
 	r.GET("/metrics", func(c *gin.Context) {
 		time.Sleep(200 * time.Millisecond)
 
-		var meter = otel.Meter("example.io/package/name")
+		var meter = otel.Meter("my-app")
 		ctx := c.Request.Context()
 
 		// Counter metric
@@ -404,13 +404,13 @@ func main() {
 		}
 		myCounter.Add(
 			ctx,
-			int64(rand.Intn(25) + 3), // Value between 1 and 3
+			int64(rand.Intn(25) + 3),
 			metric.WithAttributes(attribute.String("my_tag", "tag_value")),
 		)
 
 		// Gauge
 		myGauge, err := meter.Int64Gauge(
-			"my_guage",
+			"my_gauge",
 			metric.WithDescription("My gauge"),
 			metric.WithUnit("1"),
 		)
@@ -419,7 +419,7 @@ func main() {
 		}
 		myGauge.Record(
 			ctx,
-			int64(rand.Intn(25) + 10), // Value between 1 and 25
+			int64(rand.Intn(25) + 10),
 			metric.WithAttributes(attribute.String("my_tag", "tag_value")),
 		)
 
@@ -431,7 +431,7 @@ func main() {
 		)
 		myHistogram.Record(
 			ctx,
-			float64(rand.Intn(16) + 10), // Value between 10 and 25
+			float64(rand.Intn(16) + 10),
 			metric.WithAttributes(attribute.String("my_tag", "tag_value")),
 		)
 

--- a/php/symfony-collector/app/composer.json
+++ b/php/symfony-collector/app/composer.json
@@ -9,6 +9,7 @@
         "ext-iconv": "*",
         "open-telemetry/exporter-otlp": "^1.3",
         "open-telemetry/opentelemetry-auto-symfony": "^1.0",
+        "open-telemetry/opentelemetry-logger-monolog": "^1.1",
         "open-telemetry/sdk": "^1.6",
         "php-http/guzzle7-adapter": "^1.1",
         "symfony/console": "7.3.*",

--- a/php/symfony-collector/app/composer.lock
+++ b/php/symfony-collector/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26f95a598e95b1a6e16fd78afc34afa4",
+    "content-hash": "d14411b90bcb22732fe83734cc703241",
     "packages": [
         {
             "name": "brick/math",
@@ -517,6 +517,109 @@
             "time": "2025-03-27T12:30:47+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-24T10:02:05+00:00"
+        },
+        {
             "name": "nyholm/psr7-server",
             "version": "1.1.0",
             "source": {
@@ -906,6 +1009,65 @@
                 "source": "https://github.com/opentelemetry-php/contrib-auto-symfony/tree/1.0.2"
             },
             "time": "2025-07-09T00:12:10+00:00"
+        },
+        {
+            "name": "open-telemetry/opentelemetry-logger-monolog",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/contrib-logger-monolog.git",
+                "reference": "e188fa2c2fba5f69f92913f8ec486398e89ef971"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/contrib-logger-monolog/zipball/e188fa2c2fba5f69f92913f8ec486398e89ef971",
+                "reference": "e188fa2c2fba5f69f92913f8ec486398e89ef971",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "^1.1|^2|^3",
+                "open-telemetry/api": "^1.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "google/protobuf": ">=3.5.0",
+                "guzzlehttp/guzzle": "^7.4",
+                "nyholm/psr7": "^1.6",
+                "open-telemetry/exporter-otlp": ">=1.0",
+                "open-telemetry/sdk": ">=1.0",
+                "phan/phan": "^5.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "vimeo/psalm": "6.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OpenTelemetry\\Contrib\\Logs\\Monolog\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "OpenTelemetry Monolog handler.",
+            "homepage": "https://opentelemetry.io",
+            "keywords": [
+                "handler",
+                "logs",
+                "monolog",
+                "open-telemetry",
+                "opentelemetry",
+                "otel"
+            ],
+            "support": {
+                "source": "https://github.com/opentelemetry-php/contrib-logger-monolog/tree/1.1.0"
+            },
+            "time": "2025-02-25T01:30:01+00:00"
         },
         {
             "name": "open-telemetry/sdk",

--- a/php/symfony-collector/app/config/routes.yaml
+++ b/php/symfony-collector/app/config/routes.yaml
@@ -15,3 +15,11 @@ slow:
 error:
     path: /error
     controller: App\Controller\HomeController::error
+
+logs:
+    path: /logs
+    controller: App\Controller\HomeController::logs
+
+metrics:
+    path: /metrics
+    controller: App\Controller\HomeController::metrics

--- a/php/symfony-collector/app/src/Controller/HomeController.php
+++ b/php/symfony-collector/app/src/Controller/HomeController.php
@@ -5,6 +5,11 @@ namespace App\Controller;
 use OpenTelemetry\API\Trace\Span;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\LogRecord;
+use OpenTelemetry\API\Logs\Severity;
+use Monolog\Logger;
+use OpenTelemetry\Contrib\Logs\Monolog\Handler as OpenTelemetryHandler;
 
 class HomeController extends AbstractController
 {
@@ -24,5 +29,83 @@ class HomeController extends AbstractController
     public function error(): Response
     {
         throw new \Exception('Uh oh!');
+    }
+
+    public function logs(): Response
+    {
+        // Stand-alone OpenTelemetry logging
+        $loggerProvider = Globals::loggerProvider();
+        $otelLogger = $loggerProvider->getLogger('my-app');
+
+        // Log a message using OpenTelemetry directly
+        $otelLogger->emit(
+            (new LogRecord('Log message line'))
+                ->setSeverityNumber(Severity::INFO)
+        );
+
+        // Log with attributes
+        $otelLogger->emit(
+            (new LogRecord('Generating invoice for customer'))
+                ->setSeverityNumber(Severity::INFO)
+                ->setAttributes(['customer_id' => 'cust_123'])
+        );
+
+        // Additional OpenTelemetry logging with attributes
+        $otelLogger->emit(
+            (new LogRecord('Log message using OpenTelemetry interface'))
+                ->setSeverityNumber(Severity::INFO)
+        );
+        $otelLogger->emit(
+            (new LogRecord('Something might be wrong'))
+                ->setSeverityNumber(Severity::WARN)
+        );
+        $otelLogger->emit(
+            (new LogRecord('An error occurred'))
+                ->setSeverityNumber(Severity::ERROR)
+                ->setAttributes(['error_code' => 500])
+        );
+
+        // Monolog with OpenTelemetry handler
+        $loggerProvider = Globals::loggerProvider();
+        $handler = new OpenTelemetryHandler($loggerProvider, 'info', true);
+        $logger = new Logger('app', [$handler]);
+        
+        $logger->info('Log message with context - Monolog with OpenTelemetry handler', ['user_id' => 123]);
+        $logger->warning('Something might be wrong - Monolog with OpenTelemetry handler');
+        $logger->error('An error occurred - Monolog with OpenTelemetry handler', ['error_code' => 500]);
+
+        return new Response('Logs were sent!');
+    }
+
+    public function metrics(): Response
+    {
+        // Get the meter from the global meter provider
+        $meterProvider = Globals::meterProvider();
+        $meter = $meterProvider->getMeter('my-app');
+
+        // Counter metric
+        $counter = $meter->createCounter('my_counter');
+        $counter->add(1);
+        $counter->add(1);
+
+        // Gauge metric  
+        $gauge = $meter->createGauge('my_gauge');
+        $gauge->record(100);
+        $gauge->record(10);
+
+        // Histogram metric for distributions (measurements)
+        $histogram = $meter->createHistogram('my_histogram');
+        $histogram->record(100);
+        $histogram->record(110);
+
+        // Metrics with attributes (tags)
+        $counter = $meter->createCounter('my_tagged_counter');
+        $counter->add(1, ['region' => 'eu']);
+        $gauge = $meter->createGauge('my_tagged_gauge');
+        $gauge->record(200, ['region' => 'asia']);
+        $histogram = $meter->createHistogram('my_tagged_histogram');
+        $histogram->record(150, ['region' => 'us']);
+
+        return new Response('Metrics were sent!');
     }
 }

--- a/php/symfony-collector/app/templates/home/index.html.twig
+++ b/php/symfony-collector/app/templates/home/index.html.twig
@@ -11,6 +11,8 @@
     <ul>
       <li><a href="/slow">Slow Route (3 second delay)</a></li>
       <li><a href="/error">Error Route (throws exception)</a></li>
+      <li><a href="/logs">Logs Route (sends logs using OpenTelemetry and Monolog)</a></li>
+      <li><a href="/metrics">Metrics Route (sends counter, gauge, and histogram metrics)</a></li>
     </ul>
   </div>
 {% endblock %}


### PR DESCRIPTION
Add endpoints that emit logs and metrics, where missing, to some of the Go, Java and PHP test setups.

This PR is a complement to the docs' PR: https://github.com/appsignal/appsignal-docs/pull/2786