### PR TITLE
Ruby app should raise error on error cause route

### DIFF
--- a/ruby/rails8-sidekiq-collector/app/app/controllers/examples_controller.rb
+++ b/ruby/rails8-sidekiq-collector/app/app/controllers/examples_controller.rb
@@ -48,7 +48,7 @@ class ExamplesController < ApplicationController
     CauseCauser.new.error
   rescue => e
     puts e.backtrace
-    render :html => "foo"
+    raise
   end
 
   def custom_error


### PR DESCRIPTION
Otherwise we don't see the error reported to AppSignal.

[skip review]