### PR TITLE
Pin `click` to fix `hatch` issue

### DIFF
--- a/python/django4-asgi/commands/run
+++ b/python/django4-asgi/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/django4-celery/commands/run
+++ b/python/django4-celery/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/django4-wsgi/commands/run
+++ b/python/django4-wsgi/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/fastapi-databases/commands/run
+++ b/python/fastapi-databases/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/fastapi/commands/run
+++ b/python/fastapi/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/flask-pika/commands/run
+++ b/python/flask-pika/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/flask-sqlalchemy/commands/run
+++ b/python/flask-sqlalchemy/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/flask/commands/run
+++ b/python/flask/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 

--- a/python/starlette/commands/run
+++ b/python/starlette/commands/run
@@ -6,7 +6,7 @@ pip3 install --upgrade pip
 
 cd /integration
 
-pip3 install hatch
+pip3 install hatch "click<8.3.0"
 hatch clean
 hatch run build:me
 


### PR DESCRIPTION
Pin `click` to version `<8.3.0` to fix a breaking change in the latest minor release that causes Hatch to break.

See also https://github.com/appsignal/appsignal-python/pull/245.