### PR TITLE
Update the list of commands in `rake app:new` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -108,7 +108,7 @@ namespace :app do
     FileUtils.mkdir_p "#{@app}/commands"
 
     # Copy command scripts
-    %w(console diagnose demo run).each do |command|
+    %w(console diagnose prepare run).each do |command|
       FileUtils.cp "support/templates/skeleton/commands/#{command}", "#{@app}/commands/#{command}"
     end
 


### PR DESCRIPTION
Right now the `rake app=lang/app app:new` task references files that are no longer in the `/support/templates/sketelon/commands` directory.

[skip ci]