### PR TITLE
Don't start if an error occurred during app start

### DIFF
--- a/nodejs/express-bullmq/commands/run
+++ b/nodejs/express-bullmq/commands/run
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 echo "Install, build and link integration"
 (
 cd /integration

--- a/nodejs/express-rabbitmq/commands/run
+++ b/nodejs/express-rabbitmq/commands/run
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 echo "Install, link and build integration"
 (
 cd /integration

--- a/nodejs/express-redis/commands/run
+++ b/nodejs/express-redis/commands/run
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 echo "Install, link and build integration"
 (
 cd /integration

--- a/php/symfony-collector/commands/run
+++ b/php/symfony-collector/commands/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 cd /var/www/html
 


### PR DESCRIPTION
Add `set -eu` to exit the run script if a child process ran into a problem or if a variable was undefined.