### PR TITLE
Install Python integration from folder in Django 5 + Celery test setup

### DIFF
--- a/python/django5-celery/commands/run
+++ b/python/django5-celery/commands/run
@@ -4,10 +4,17 @@ set -eu
 
 pip3 install --upgrade pip
 
+cd /integration
+
+pip3 install hatch "click<8.3.0"
+hatch clean
+hatch run build:me
+
 cd /app
 
 echo "Installing dependencies"
 pip3 install -r requirements.txt
+pip3 install /integration/dist/* --force-reinstall
 
 echo "Running migrations"
 python3 manage.py migrate

--- a/python/django5-celery/docker-compose.yml
+++ b/python/django5-celery/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - APPSIGNAL_APP_ENV=dev
     volumes:
       - ./app:/app
+      - ../integration:/integration
   tests:
     build: ../../support/server-tests
     image: server-tests


### PR DESCRIPTION
The `django5-celery` test setup installed AppSignal for Python from PyPI, rather than from the `python/integration` folder in this repository, as all other test setups do.

Make it install AppSignal for Python from the `python/integration` folder, like the other test setups.