### PR TITLE
Add a timeout to github test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   CACHE_VERSION: v1
   RUNNING_IN_CI: true
-  JOB_TIMEOUT_MINUTES: 10
+  JOB_TIMEOUT_MINUTES: &timeout 10
 
 jobs:
   build-processmon:
@@ -44,7 +44,7 @@ jobs:
     name: Run tests for Elixir test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +78,7 @@ jobs:
     name: Run tests for Java test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +107,7 @@ jobs:
     name: Run tests for Go test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:
@@ -140,7 +140,7 @@ jobs:
     name: Run tests for JavaScript test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:
@@ -182,7 +182,7 @@ jobs:
     name: Run tests for Node.js test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:
@@ -230,7 +230,7 @@ jobs:
     name: Run tests for Ruby test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:
@@ -286,7 +286,7 @@ jobs:
     name: Run tests for Python test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:
@@ -319,7 +319,7 @@ jobs:
     name: Run tests for PHP test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
-    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
+    timeout-minutes: *timeout
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
 env:
   CACHE_VERSION: v1
   RUNNING_IN_CI: true
+  JOB_TIMEOUT_MINUTES: 10
 
 jobs:
   build-processmon:
@@ -43,6 +44,7 @@ jobs:
     name: Run tests for Elixir test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +78,7 @@ jobs:
     name: Run tests for Java test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +107,7 @@ jobs:
     name: Run tests for Go test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +140,7 @@ jobs:
     name: Run tests for JavaScript test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:
@@ -177,6 +182,7 @@ jobs:
     name: Run tests for Node.js test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:
@@ -224,6 +230,7 @@ jobs:
     name: Run tests for Ruby test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:
@@ -279,6 +286,7 @@ jobs:
     name: Run tests for Python test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:
@@ -311,6 +319,7 @@ jobs:
     name: Run tests for PHP test setups
     runs-on: ubuntu-22.04
     needs: build-processmon
+    timeout-minutes: ${{ env.JOB_TIMEOUT_MINUTES }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add a timeout of 10 minutes for test jobs.

Right now jobs have the default timeout, which is 360 minutes. Recently, a Node.js test job ran for 2h 20m 13s. 
See https://github.com/appsignal/test-setups/actions/runs/18198404643/job/51810713493.

Most test jobs finish within 2-3 minutes, the longest being PHP tests, running for 4 minutes.