### PR TITLE
Add a task for switching between environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 nodejs/opentelemetry-instrumentation-bullmq
 .DS_Store
 appsignal_key.env
+.appsignal_environment
+appsignal_key_*.env
 .env
 yarn-error.log
 node_modules

--- a/Rakefile
+++ b/Rakefile
@@ -91,6 +91,29 @@ def render_erb(file)
   ERB.new(File.read(file)).result
 end
 
+namespace :env do
+  desc "Send data to local devenv"
+  task :local do
+    FileUtils.cp "./appsignal_key_local.env", "./appsignal_key.env"
+    File.write ".appsignal_environment", "local"
+  end
+  task :dev => :local
+  task :development => :local
+
+  desc "Send data to staging"
+  task :prod do
+    FileUtils.cp "./appsignal_key_prod.env", "./appsignal_key.env"
+    File.write ".appsignal_environment", "production"
+  end
+  task :production => :prod
+
+  desc "Send data to production"
+  task :staging do
+    FileUtils.cp "./appsignal_key_staging.env", "./appsignal_key.env"
+    File.write ".appsignal_environment", "staging"
+  end
+end
+
 namespace :app do
   desc "Open the browser pointing to the app"
   task :open do
@@ -137,6 +160,13 @@ namespace :app do
 
     @app = get_app
     puts "Starting #{@app}"
+
+    if File.exist?(".appsignal_environment")
+      env = File.read(".appsignal_environment").strip.upcase
+      puts "=" * 50
+      puts "ENVIRONMENT: #{env}"
+      puts "=" * 50
+    end
 
     puts "Copying processmon"
     FileUtils.rm_f "#{@app}/commands/processmon"


### PR DESCRIPTION
This is what I use to quickly switch between different environments. I run `rake env:local` or `rake env:staging`, or `rake env:prod` and that's it.

It's basically just 3 `appsignal_key_[env].env` files, and an `.appsignal_environment` file that tracks which env file is used in `appsignal_key.env`. A command like `rake env:local` copies `appsignal_key_local.env` to `appsignal_key.env`, which then gets used in all test-setups.

I haven't made this work with `rake global:set_push_api_key`, but I will do that if this is something that we actually want to add.