### PR TITLE
Fix failing CI: Elixir plug compile and Node 20 npm

### DIFF
--- a/elixir/plug-ecto/Dockerfile
+++ b/elixir/plug-ecto/Dockerfile
@@ -1,7 +1,7 @@
-FROM elixir:1.14.1
+FROM elixir:1.16.2
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2023-01-11
+ENV REFRESHED_AT=2026-07-09
 
 RUN apt-get update && apt-get install -y less
 

--- a/elixir/plug-oban/Dockerfile
+++ b/elixir/plug-oban/Dockerfile
@@ -1,7 +1,7 @@
-FROM elixir:1.14.1
+FROM elixir:1.16.2
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2022-12-22
+ENV REFRESHED_AT=2026-07-09
 
 RUN apt-get update && apt-get install -y less
 

--- a/elixir/plug/Dockerfile
+++ b/elixir/plug/Dockerfile
@@ -1,7 +1,7 @@
-FROM elixir:1.14.1
+FROM elixir:1.16.2
 
 # Update this if the docker image changes
-ENV REFRESHED_AT=2023-01-11
+ENV REFRESHED_AT=2026-07-09
 
 RUN apt-get update && apt-get install -y less
 

--- a/elixir/plug/app/mix.exs
+++ b/elixir/plug/app/mix.exs
@@ -27,8 +27,8 @@ defmodule PlugExample.MixProject do
   defp deps do
     [
       {:plug_cowboy, "~> 2.0"},
-      {:appsignal, path: "#{integration_path}/appsignal-elixir", override: true},
-      {:appsignal_plug, path: "#{integration_path}/appsignal-elixir-plug"}
+      {:appsignal, path: "#{integration_path()}/appsignal-elixir", override: true},
+      {:appsignal_plug, path: "#{integration_path()}/appsignal-elixir-plug"}
     ]
   end
 end

--- a/nodejs/nextjs-13-app/Dockerfile
+++ b/nodejs/nextjs-13-app/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y ruby less
 # Update npm
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=/home/node/.npm-global/bin:$PATH
-RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@latest
+# npm@12 dropped Node 20; pin to npm@11, the last line that supports it.
+RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@11
 
 # Configure mono
 ENV PATH=/root/mono/bin:$PATH

--- a/nodejs/nextjs-14-app/Dockerfile
+++ b/nodejs/nextjs-14-app/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y ruby less
 # Update npm
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=/home/node/.npm-global/bin:$PATH
-RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@latest
+# npm@12 dropped Node 20; pin to npm@11, the last line that supports it.
+RUN mkdir -p $NPM_CONFIG_PREFIX/lib && npm install -g npm@11
 
 # Configure mono
 ENV PATH=/root/mono/bin:$PATH

--- a/nodejs/nextjs-14-pages/commands/run
+++ b/nodejs/nextjs-14-pages/commands/run
@@ -2,8 +2,9 @@
 
 set -eu
 
+# npm@12 dropped Node 20; pin to npm@11, the last line that supports it.
 echo "Installing compatible NPM version"
-npm install -g npm@latest
+npm install -g npm@11
 
 # The following block is commented because of an issue with
 # Next.js' internal use of Webpack and `npm link`-ed projects.


### PR DESCRIPTION
Two unrelated dependency breakages are failing CI on `main` (and on every
scheduled run). Neither is specific to any feature branch; this fixes both.

### [Bump plug test setups to Elixir 1.16.2](https://github.com/appsignal/test-setups/commit/ecea788e47edf88aa9650ce720ed0ce271b7b5ac)

plug 1.20 requires Elixir ~> 1.15, so the plug, plug-ecto and plug-oban
setups stopped compiling on their pinned elixir:1.14.1 image once plug
1.20 was released. Bump them to elixir:1.16.2, matching the other Elixir
setups that already build on CI.

### [Pin npm to 11 in Next.js setups on Node 20](https://github.com/appsignal/test-setups/commit/6215cdf8a4f87cfe866d48f6e41ab715d9a754da)

npm@12 dropped support for Node 20, so `npm install -g npm@latest` began
failing on the node:20 based Next.js setups: at build time for the app
router setups, and on boot for the pages router one. Pin npm to 11, the
last line that still supports Node 20, and keep the base image as is
since these older Next.js versions are finicky on newer Node.

### [Call integration_path() in plug mix.exs](https://github.com/appsignal/test-setups/commit/350ba523cc57834b01ff97ca942d94a4e6822482)

Elixir 1.16 turns the bare `integration_path` reference into a hard
"undefined variable" error instead of the warning it was on 1.14, where
it was auto-expanded to the function call. Add the parentheses, matching
plug-ecto and plug-oban.
