### PR TITLE
Stop instrumenting the Delayed Job worker as a rake task

### DIFF
--- a/ruby/rails8-delayed-job/app/config/appsignal.rb
+++ b/ruby/rails8-delayed-job/app/config/appsignal.rb
@@ -1,5 +1,10 @@
 Appsignal.configure do |config|
-  config.enable_rake_performance_instrumentation = true
+  # This worker is booted with `rake jobs:work`. With rake performance
+  # instrumentation on, the rake task opens a "rake" transaction that each job
+  # reuses, so jobs are recorded under the "rake" namespace instead of
+  # "background_job" (and lose their trace context in collector mode).
+  # See https://github.com/appsignal/appsignal-ruby/issues/1536.
+  config.enable_rake_performance_instrumentation = false
 
   config.activate_if_environment(:development, :production)
 end


### PR DESCRIPTION
rails8-delayed-job boots its worker with `rake jobs:work` and had
rake performance instrumentation enabled. That wraps the long-running
worker task in a "rake" transaction which each job reuses, so jobs were
recorded under the `rake` namespace instead of `background_job` (and, in
collector mode, as SERVER spans that drop their trace context).

Disable it so jobs are recorded as background jobs again. This works
around, rather than fixes, appsignal/appsignal-ruby#1536.