### PR TITLE
Add Delayed Job appsignal_name example

### DIFF
--- a/ruby/rails8-delayed-job/app/app/controllers/jobs_controller.rb
+++ b/ruby/rails8-delayed-job/app/app/controllers/jobs_controller.rb
@@ -34,6 +34,12 @@ class JobsController < ApplicationController
       else
         PerformanceJob.new.deliver_async("Performance test")
       end
+    when "AppsignalNameJob"
+      if future
+        AppsignalNameJob.new.delay(:run_at => DELAY_DURATION.from_now).deliver_async("appsignal_name test")
+      else
+        AppsignalNameJob.new.deliver_async("appsignal_name test")
+      end
     end
 
     redirect_to({ :action => :index }, :notice => "Job queued")

--- a/ruby/rails8-delayed-job/app/app/jobs/appsignal_name_job.rb
+++ b/ruby/rails8-delayed-job/app/app/jobs/appsignal_name_job.rb
@@ -1,0 +1,17 @@
+# A Delayed Job job that overrides its AppSignal action name through the
+# `appsignal_name` method. When it performs, the transaction's action is the
+# `appsignal_name` value rather than the job class name.
+class AppsignalNameJob
+  def deliver(argument = nil)
+    puts "delivered AppsignalNameJob: #{argument}"
+  end
+
+  def deliver_async(argument = nil)
+    deliver(argument)
+  end
+  handle_asynchronously :deliver_async, :queue => "default"
+
+  def appsignal_name
+    "AppsignalNameJob#custom_action"
+  end
+end

--- a/ruby/rails8-delayed-job/app/app/views/jobs/index.html.erb
+++ b/ruby/rails8-delayed-job/app/app/views/jobs/index.html.erb
@@ -15,6 +15,9 @@
   <li>
     <%= link_to "PerformanceJob", queue_jobs_path(:job => "PerformanceJob", :future => "false") %>
   </li>
+  <li>
+    <%= link_to "AppsignalNameJob", queue_jobs_path(:job => "AppsignalNameJob", :future => "false") %>
+  </li>
 </ul>
 
 <h1>Schedule Delayed Job jobs in the future</h1>
@@ -35,5 +38,8 @@
   </li>
   <li>
     <%= link_to "PerformanceJob", queue_jobs_path(:job => "PerformanceJob", :future => "true") %>
+  </li>
+  <li>
+    <%= link_to "AppsignalNameJob", queue_jobs_path(:job => "AppsignalNameJob", :future => "true") %>
   </li>
 </ul>


### PR DESCRIPTION
Delayed Job lets a job override its AppSignal action name by defining an `appsignal_name` method. The `rails8-delayed-job` setup had no job exercising that, so add one whose performed transaction is named after the override rather than the job class.

The job is reachable from the jobs index page (immediate and future variants), like the other example jobs.