### PR TITLE
Prevent processmon restarts

### DIFF
--- a/python/django4-asgi/app/processmon.downstream.toml
+++ b/python/django4-asgi/app/processmon.downstream.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # Downstream web server on :4002 (no celery here; that is the worker split).
 [processes.django]

--- a/python/django4-asgi/app/processmon.toml
+++ b/python/django4-asgi/app/processmon.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django4-asgi/app/processmon.worker.toml
+++ b/python/django4-asgi/app/processmon.worker.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/django4-celery/app/processmon.downstream.toml
+++ b/python/django4-celery/app/processmon.downstream.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # The downstream service is a second instance of the same Django app on a
 # different port. It receives the HTTP request the `app` service makes, so the

--- a/python/django4-celery/app/processmon.toml
+++ b/python/django4-celery/app/processmon.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django4-celery/app/processmon.worker.toml
+++ b/python/django4-celery/app/processmon.worker.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/django4-wsgi/app/processmon.downstream.toml
+++ b/python/django4-wsgi/app/processmon.downstream.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # Downstream web server on :4002 (no celery here; that is the worker split).
 [processes.django]

--- a/python/django4-wsgi/app/processmon.toml
+++ b/python/django4-wsgi/app/processmon.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 [processes.django]
 command = "gunicorn"

--- a/python/django4-wsgi/app/processmon.worker.toml
+++ b/python/django4-wsgi/app/processmon.worker.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/django5-celery-opentelemetry/app/processmon.toml
+++ b/python/django5-celery-opentelemetry/app/processmon.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django5-celery/app/processmon.downstream.toml
+++ b/python/django5-celery/app/processmon.downstream.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # Downstream web server on :4002 (no celery here; that is the worker split).
 [processes.django]

--- a/python/django5-celery/app/processmon.toml
+++ b/python/django5-celery/app/processmon.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django5-celery/app/processmon.worker.toml
+++ b/python/django5-celery/app/processmon.worker.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/flask-pika/app/processmon.toml
+++ b/python/flask-pika/app/processmon.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 [processes.flask]
 command = "flask"

--- a/python/flask-pika/app/processmon.worker.toml
+++ b/python/flask-pika/app/processmon.worker.toml
@@ -1,5 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
+ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/ruby/jruby-rails6/app/processmon.toml
+++ b/ruby/jruby-rails6/app/processmon.toml
@@ -1,6 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["tmp", "log", "public/packs", "node_modules/.cache"]
+ignore = ["db", "tmp", "log", "public/packs", "node_modules/.cache"]
 
 [[paths_to_watch]]
 path = "/integration"

--- a/ruby/rails6-shoryuken/app/processmon.downstream.toml
+++ b/ruby/rails6-shoryuken/app/processmon.downstream.toml
@@ -1,6 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["tmp", "log", "public/packs", "node_modules/.cache"]
+ignore = ["db", "tmp", "log", "public/packs", "node_modules/.cache"]
 
 [[paths_to_watch]]
 path = "/integration"

--- a/ruby/rails6-shoryuken/app/processmon.toml
+++ b/ruby/rails6-shoryuken/app/processmon.toml
@@ -1,6 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["tmp", "log", "public/packs", "node_modules/.cache"]
+ignore = ["db", "tmp", "log", "public/packs", "node_modules/.cache"]
 
 [[paths_to_watch]]
 path = "/integration"

--- a/ruby/rails6-shoryuken/app/processmon.worker.toml
+++ b/ruby/rails6-shoryuken/app/processmon.worker.toml
@@ -1,6 +1,6 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["tmp", "log", "public/packs", "node_modules/.cache"]
+ignore = ["db", "tmp", "log", "public/packs", "node_modules/.cache"]
 
 [[paths_to_watch]]
 path = "/integration"

--- a/ruby/rails8-resque/app/processmon.downstream.toml
+++ b/ruby/rails8-resque/app/processmon.downstream.toml
@@ -1,6 +1,7 @@
 [[paths_to_watch]]
 path = "/app"
 ignore = [
+  "storage",
   "tmp",
   "log",
   "node_modules",

--- a/ruby/rails8-resque/app/processmon.toml
+++ b/ruby/rails8-resque/app/processmon.toml
@@ -1,6 +1,7 @@
 [[paths_to_watch]]
 path = "/app"
 ignore = [
+  "storage",
   "tmp",
   "log",
   "node_modules",

--- a/ruby/rails8-resque/app/processmon.worker.toml
+++ b/ruby/rails8-resque/app/processmon.worker.toml
@@ -1,6 +1,7 @@
 [[paths_to_watch]]
 path = "/app"
 ignore = [
+  "storage",
   "tmp",
   "log",
   "node_modules",

--- a/ruby/rails8-sidekiq-opentelemetry/app/processmon.toml
+++ b/ruby/rails8-sidekiq-opentelemetry/app/processmon.toml
@@ -1,6 +1,7 @@
 [[paths_to_watch]]
 path = "/app"
 ignore = [
+  "storage",
   "tmp",
   "log",
   "node_modules",

--- a/ruby/rails8-sidekiq/app/processmon.toml
+++ b/ruby/rails8-sidekiq/app/processmon.toml
@@ -1,6 +1,7 @@
 [[paths_to_watch]]
 path = "/app"
 ignore = [
+  "storage",
   "tmp",
   "log",
   "node_modules",

--- a/ruby/rails8-sidekiq/app/processmon.worker.toml
+++ b/ruby/rails8-sidekiq/app/processmon.worker.toml
@@ -1,6 +1,7 @@
 [[paths_to_watch]]
 path = "/app"
 ignore = [
+  "storage",
   "tmp",
   "log",
   "node_modules",


### PR DESCRIPTION
Two processmon configuration fixes so setups stop restarting themselves on files they write at runtime. Found while testing the collector-mode work from #375.

### [Ignore SQLite DB dirs in processmon to stop restart churn](https://github.com/appsignal/test-setups/commit/49eeeefaf124f7093ea0b9527e47acc1f8617c7b)

processmon watches /app and restarts the process whenever a watched file changes. SQLite writes its database and WAL/journal files inside the app tree, so every DB write rewrote those files and processmon restarted the process on each write. On the SQLite-backed setups this made the worker (and web) containers restart continuously, so they never stayed up long enough to process jobs or flush telemetry.

Add the SQLite directory to each affected config's ignore list:

- Rails 8 setups keep the database in storage/, so ignore `storage` (matching what rails8-delayed-job already did). storage/ holds only databases, so ignoring it costs nothing.
- Rails 6 setups keep it in db/, so ignore `db`. That directory also holds migrations and schema.rb, which these test setups do not hot-reload, so ignoring the whole directory is acceptable.

processmon matches ignore entries with component-wise starts_with, so a directory entry catches the .sqlite3, -wal and -shm files inside it, while a single-file entry would not catch its -wal/-shm siblings. This is the same reason the nestjs setups list prisma/dev.db and prisma/dev.db-journal separately.

### [Ignore __pycache__ in Python processmon configs](https://github.com/appsignal/test-setups/commit/18dc14fdfc5647b3f144c5a64b8989825f83895f)

The Django and Flask setups watched /app without ignoring __pycache__. Python writes .pyc files there on import, so the first request that triggers a lazy import rewrote __pycache__ and processmon restarted the process once. It is a single reboot rather than continuous churn, but it is one more than necessary.

Ignore __pycache__ in every Python config that lacked it, matching the fastapi, fastapi-databases and starlette setups that already did.

[skip changeset]
