### PR TITLE
Replace nonexistent Appsignal.apply_request call

### DIFF
--- a/ruby/rails8-que/app/app/controllers/examples_controller.rb
+++ b/ruby/rails8-que/app/app/controllers/examples_controller.rb
@@ -35,7 +35,9 @@ class ExamplesController < ApplicationController
     raise "uh oh"
   rescue StandardError => error
     Appsignal.send_error(error) do
-      Appsignal.apply_request(request)
+      Appsignal.set_action("#{self.class.name}##{action_name}")
+      Appsignal.add_params(request.params)
+      Appsignal.add_headers(request.env)
     end
 
     raise

--- a/ruby/rails8-resque/app/app/controllers/examples_controller.rb
+++ b/ruby/rails8-resque/app/app/controllers/examples_controller.rb
@@ -35,7 +35,9 @@ class ExamplesController < ApplicationController
     raise "uh oh"
   rescue StandardError => error
     Appsignal.send_error(error) do
-      Appsignal.apply_request(request)
+      Appsignal.set_action("#{self.class.name}##{action_name}")
+      Appsignal.add_params(request.params)
+      Appsignal.add_headers(request.env)
     end
 
     raise

--- a/ruby/rails8-sidekiq/app/app/controllers/examples_controller.rb
+++ b/ruby/rails8-sidekiq/app/app/controllers/examples_controller.rb
@@ -35,7 +35,9 @@ class ExamplesController < ApplicationController
     raise "uh oh"
   rescue StandardError => error
     Appsignal.send_error(error) do
-      Appsignal.apply_request(request)
+      Appsignal.set_action("#{self.class.name}##{action_name}")
+      Appsignal.add_params(request.params)
+      Appsignal.add_headers(request.env)
     end
 
     raise


### PR DESCRIPTION
The `custom_error` action in the Rails 8 example apps called `Appsignal.apply_request(request)` inside the `send_error` block. That helper has never existed, so the block raised `NoMethodError` instead of attaching the request to the reported error.

Use the real public helpers to attach the request context: set the action, and add the request's params and headers. Now `/custom_error` reports the error with its request context, as intended.

Found while investigating a collector-mode trace-context merge. The raising block also exposed a gap in the Ruby integration, fixed separately in appsignal/appsignal-ruby#1544 (a raising error block left the transaction unfinished). This PR only fixes the example app.