### PR TITLE
Regenerate sinatra-alpine lock for musl platform

### DIFF
--- a/ruby/sinatra-alpine/app/Gemfile.lock
+++ b/ruby/sinatra-alpine/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /integration
   specs:
-    appsignal (4.8.0)
+    appsignal (4.8.6)
       logger
       rack (>= 2.0.0)
 
@@ -35,51 +35,55 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    base64 (0.3.0)
     bigdecimal (4.1.2)
-    builder (3.2.4)
-    concurrent-ruby (1.2.2)
-    crass (1.0.6)
-    date (3.3.3)
-    debug (1.9.0)
+    builder (3.3.0)
+    concurrent-ruby (1.3.7)
+    crass (1.0.7)
+    date (3.5.1)
+    debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    erubi (1.12.0)
+    erb (6.0.4)
+    erubi (1.13.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-protobuf (4.35.1-aarch64-linux-gnu)
+    google-protobuf (4.35.1-aarch64-linux-musl)
       bigdecimal
       rake (~> 13.3)
     googleapis-common-protos-types (1.23.0)
       google-protobuf (~> 4.26)
-    i18n (1.14.1)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    io-console (0.7.0)
-    irb (1.10.1)
-      rdoc
-      reline (>= 0.3.8)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     logger (1.7.0)
-    loofah (2.21.3)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
+    mail (2.9.1)
+      logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
-    mini_mime (1.1.2)
-    minitest (5.18.1)
-    mustermann (3.0.0)
-      ruby2_keywords (~> 0.0.1)
-    net-imap (0.3.6)
+    mini_mime (1.1.5)
+    minitest (5.27.0)
+    mustermann (3.1.1)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
-    net-smtp (0.3.3)
+    net-smtp (0.5.1)
       net-protocol
-    nokogiri (1.15.2-aarch64-linux)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
     opentelemetry-api (1.8.0)
       logger
@@ -131,41 +135,51 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.36.0)
       opentelemetry-api (~> 1.0)
-    psych (5.1.1.1)
-      stringio
-    racc (1.7.1)
-    rack (2.2.7)
-    rack-protection (3.0.6)
-      rack
-    rack-test (2.1.0)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    rack-test (2.2.0)
       rack (>= 1.3)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
-      loofah (~> 2.21)
-      nokogiri (~> 1.14)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rake (13.4.2)
-    rdoc (6.6.1)
-      psych (>= 4.0.0)
-    reline (0.4.1)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    reline (0.6.3)
       io-console (~> 0.5)
-    ruby2_keywords (0.0.5)
-    sinatra (3.0.6)
+    sinatra (3.2.0)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.0.6)
+      rack-protection (= 3.2.0)
       tilt (~> 2.0)
-    stringio (3.1.0)
     thread_safe (0.3.6)
-    tilt (2.2.0)
-    timeout (0.4.0)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tsort (0.2.0)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
-    webrick (1.8.1)
+    webrick (1.9.2)
 
 PLATFORMS
-  aarch64-linux
+  aarch64-linux-musl
 
 DEPENDENCIES
   actionmailer (= 5.2.0)
@@ -182,4 +196,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.33
+   2.4.10


### PR DESCRIPTION
sinatra-alpine runs on an Alpine (musl) image, but its committed Gemfile.lock carried glibc platform gems (google-protobuf and nokogiri as `*-aarch64-linux-gnu`) and `BUNDLED WITH 2.2.33`. On Apple Silicon that old bundler cannot reconcile the musl container against the glibc lock once the appsignal path gem moves ahead of the pinned version, and it aborts with `undefined method 'full_name' for nil` ([rubygems/rubygems#5985](https://github.com/rubygems/rubygems/issues/5985)), so the app never boots.

Regenerate the lockfile inside the Alpine container so it pins the musl platform gems and a current bundler. x86_64 CI was unaffected because its platform never matched the aarch64 lock and it re-resolved on every run; this repairs local Apple Silicon runs and brings sinatra-alpine in line with the other setups.

[skip changeset]