### PR TITLE
Set bundler path in rails6-shoryuken run-worker

### DIFF
--- a/ruby/rails6-shoryuken/commands/run-worker
+++ b/ruby/rails6-shoryuken/commands/run-worker
@@ -4,6 +4,11 @@ set -eu
 
 cd /app
 
+# Point bundler at the shared vendor/bundle the `app` service installs into.
+# (This app configures the path at runtime rather than via a BUNDLE_PATH env, so
+# each container must set it for itself.)
+bundle config set path vendor/bundle
+
 # The `app` service owns installing gems and running migrations into the shared
 # /app and /integration volumes. Wait for both before starting the worker.
 #


### PR DESCRIPTION
The rails6-shoryuken worker container never started. Its run-worker script waits for the app service to install gems by polling `bundle check`, but it never pointed bundler at the shared vendor/bundle directory. This app's older bundler writes `bundle config set path` to a per-container location that does not persist to the shared volume, so the worker checked the default gem path, never found the gems, and looped on "Gems not ready yet" forever.

run-downstream already sets the path for this reason. Add the same line to run-worker so the worker finds the installed gems and boots.

Only rails6-shoryuken hits this. The other worker setups omit the same line but still boot, because their newer bundler persists `bundle config set path` to the shared config.

[skip changeset]