### PR TITLE
Add Sidekiq delayed wrapper action name example

### DIFF
--- a/ruby/rails7-sidekiq/app/Gemfile
+++ b/ruby/rails7-sidekiq/app/Gemfile
@@ -9,6 +9,7 @@ gem "sinatra"
 gem "sinatra-contrib", require: false
 
 gem "sidekiq", "~> 7.1.6"
+gem "sidekiq-delay_extensions"
 gem "appsignal", :path => "/integration"
 gem "excon"
 gem "http"

--- a/ruby/rails7-sidekiq/app/Gemfile.lock
+++ b/ruby/rails7-sidekiq/app/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    sidekiq-delay_extensions (7.1.0)
+      sidekiq (>= 7.0)
     sinatra (4.0.0)
       mustermann (~> 3.0)
       rack (>= 3.0.0, < 4)
@@ -376,6 +378,7 @@ DEPENDENCIES
   redis (~> 4.0)
   selenium-webdriver
   sidekiq (~> 7.1.6)
+  sidekiq-delay_extensions
   sinatra
   sinatra-contrib
   sprockets-rails

--- a/ruby/rails7-sidekiq/app/app/controllers/workers_controller.rb
+++ b/ruby/rails7-sidekiq/app/app/controllers/workers_controller.rb
@@ -62,6 +62,21 @@ class WorkersController < ApplicationController
     redirect_to({ :action => :index }, :notice => "Cross-service worker queued")
   end
 
+  def delay
+    # Enqueue a job in the legacy Sidekiq delayed extension wire format
+    # (`Sidekiq::Extensions::DelayedClass` with a YAML-marshalled
+    # `[target, method, args]`). That's the format the AppSignal integration
+    # recognizes and resolves into a `Target.method` action name. Modern
+    # Sidekiq's `.delay` uses the `Sidekiq::DelayExtensions` namespace, which
+    # the integration does not match, so the job is pushed by hand here.
+    Sidekiq::Client.push(
+      "class" => "Sidekiq::Extensions::DelayedClass",
+      "queue" => "default",
+      "args" => [YAML.dump([GoalTestDelayedTarget, :run, ["delayed wrapper test"]])]
+    )
+    redirect_to({ :action => :index }, :notice => "Delayed wrapper job queued")
+  end
+
   def handle_sidekiq(worker, args:, test:, future:)
     if future
       worker.perform_in(DELAY_DURATION.from_now, *args)

--- a/ruby/rails7-sidekiq/app/app/views/workers/index.html.erb
+++ b/ruby/rails7-sidekiq/app/app/views/workers/index.html.erb
@@ -31,6 +31,17 @@ links back to the enqueue span across both apps.</p>
   <li><%= link_to "DownstreamWorker (cross-service)", cross_service_workers_path %></li>
 </ul>
 
+<h1>Queue a delayed wrapper job</h1>
+
+<p>Enqueues a job in the legacy Sidekiq delayed extension wire format. The
+AppSignal integration resolves its action name from the wrapped target and
+method, so the performed transaction is named <code>GoalTestDelayedTarget.run</code>
+rather than the internal wrapper class.</p>
+
+<ul>
+  <li><%= link_to "GoalTestDelayedTarget (delayed wrapper)", delay_workers_path %></li>
+</ul>
+
 <h1>Sidekiq monitoring page</h1>
 
 <ul>

--- a/ruby/rails7-sidekiq/app/app/workers/goal_test_delayed_target.rb
+++ b/ruby/rails7-sidekiq/app/app/workers/goal_test_delayed_target.rb
@@ -1,0 +1,8 @@
+# Target of a Sidekiq delayed job, used to check the AppSignal integration
+# resolves a delayed wrapper job's action name to `GoalTestDelayedTarget.run`
+# rather than the internal wrapper class.
+class GoalTestDelayedTarget
+  def self.run(argument = nil)
+    puts "GoalTestDelayedTarget.run #{argument}"
+  end
+end

--- a/ruby/rails7-sidekiq/app/config/initializers/delay_extensions.rb
+++ b/ruby/rails7-sidekiq/app/config/initializers/delay_extensions.rb
@@ -1,0 +1,16 @@
+require "sidekiq/delay_extensions"
+
+# Restores Sidekiq's `.delay` extensions, which were removed from Sidekiq 7.
+Sidekiq::DelayExtensions.enable_delay!
+
+# The extraction gem defines the delayed job classes under
+# `Sidekiq::DelayExtensions`, but jobs enqueued by older Sidekiq versions use
+# the `Sidekiq::Extensions` namespace. That legacy namespace is also the one
+# the AppSignal integration recognizes when resolving a delayed job's action
+# name. Alias it so such a job can be constantized and performed here.
+module Sidekiq
+  module Extensions
+  end
+end
+Sidekiq::Extensions::DelayedClass = Sidekiq::DelayExtensions::DelayedClass
+Sidekiq::Extensions::DelayedModel = Sidekiq::DelayExtensions::DelayedModel

--- a/ruby/rails7-sidekiq/app/config/routes.rb
+++ b/ruby/rails7-sidekiq/app/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     collection do
       get :queue
       get :cross_service
+      get :delay
     end
   end
   mount Sidekiq::Web => "/sidekiq"


### PR DESCRIPTION
Sidekiq 7 removed the `.delay` extensions, but the AppSignal integration
still resolves a delayed wrapper job's action name from the wrapped
target and method. No test setup exercised that path.

Add an endpoint that enqueues a job in the legacy delayed extension wire
format. The integration reads the wrapped target and method out of it, so
the performed transaction is named `GoalTestDelayedTarget.run` rather than
the internal wrapper class.

The `sidekiq-delay_extensions` gem restores the removed `.delay` code so
the worker can perform the job. That gem defines its classes under the
`Sidekiq::DelayExtensions` namespace, but the job is enqueued under the
older `Sidekiq::Extensions` namespace, which is also the one the
integration matches. An initializer aliases the two so the enqueued job
can be constantized and performed.

