### PR TITLE
Stop Python writing bytecode to avoid restarts

### DIFF
--- a/python/django4-asgi/Dockerfile
+++ b/python/django4-asgi/Dockerfile
@@ -6,6 +6,12 @@ ENV REFRESHED_AT=2023-02-08
 RUN apt-get update && \
   apt-get install -y postgresql-client git less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/django4-asgi/app/processmon.downstream.toml
+++ b/python/django4-asgi/app/processmon.downstream.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # Downstream web server on :4002 (no celery here; that is the worker split).
 [processes.django]

--- a/python/django4-asgi/app/processmon.toml
+++ b/python/django4-asgi/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django4-asgi/app/processmon.worker.toml
+++ b/python/django4-asgi/app/processmon.worker.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/django4-celery/Dockerfile
+++ b/python/django4-celery/Dockerfile
@@ -6,6 +6,12 @@ ENV REFRESHED_AT=2023-02-08
 RUN apt-get update && \
   apt-get install -y postgresql-client git less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/django4-celery/app/processmon.downstream.toml
+++ b/python/django4-celery/app/processmon.downstream.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # The downstream service is a second instance of the same Django app on a
 # different port. It receives the HTTP request the `app` service makes, so the

--- a/python/django4-celery/app/processmon.toml
+++ b/python/django4-celery/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django4-celery/app/processmon.worker.toml
+++ b/python/django4-celery/app/processmon.worker.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/django4-wsgi/Dockerfile
+++ b/python/django4-wsgi/Dockerfile
@@ -6,6 +6,12 @@ ENV REFRESHED_AT=2023-02-08
 RUN apt-get update && \
   apt-get install -y postgresql-client git less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/django4-wsgi/app/processmon.downstream.toml
+++ b/python/django4-wsgi/app/processmon.downstream.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # Downstream web server on :4002 (no celery here; that is the worker split).
 [processes.django]

--- a/python/django4-wsgi/app/processmon.toml
+++ b/python/django4-wsgi/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.django]
 command = "gunicorn"

--- a/python/django4-wsgi/app/processmon.worker.toml
+++ b/python/django4-wsgi/app/processmon.worker.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/django5-celery-opentelemetry/Dockerfile
+++ b/python/django5-celery-opentelemetry/Dockerfile
@@ -6,6 +6,12 @@ ENV REFRESHED_AT=2023-02-08
 RUN apt-get update && \
   apt-get install -y postgresql-client git less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/django5-celery-opentelemetry/app/processmon.toml
+++ b/python/django5-celery-opentelemetry/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django5-celery/Dockerfile
+++ b/python/django5-celery/Dockerfile
@@ -6,6 +6,12 @@ ENV REFRESHED_AT=2023-02-08
 RUN apt-get update && \
   apt-get install -y postgresql-client git less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/django5-celery/app/processmon.downstream.toml
+++ b/python/django5-celery/app/processmon.downstream.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # Downstream web server on :4002 (no celery here; that is the worker split).
 [processes.django]

--- a/python/django5-celery/app/processmon.toml
+++ b/python/django5-celery/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.django]
 command = "python3"

--- a/python/django5-celery/app/processmon.worker.toml
+++ b/python/django5-celery/app/processmon.worker.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/fastapi-databases/Dockerfile
+++ b/python/fastapi-databases/Dockerfile
@@ -5,6 +5,12 @@ ENV REFRESHED_AT=2023-05-23
 
 RUN apt-get update && apt-get install -y less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/fastapi-databases/app/processmon.toml
+++ b/python/fastapi-databases/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.fastapi]
 command = "uvicorn"

--- a/python/fastapi/Dockerfile
+++ b/python/fastapi/Dockerfile
@@ -5,6 +5,12 @@ ENV REFRESHED_AT=2023-05-23
 
 RUN apt-get update && apt-get install -y less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/fastapi/app/processmon.toml
+++ b/python/fastapi/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.fastapi]
 command = "uvicorn"

--- a/python/flask-pika/Dockerfile
+++ b/python/flask-pika/Dockerfile
@@ -5,6 +5,12 @@ ENV REFRESHED_AT=2023-05-23
 
 RUN apt-get update && apt-get install -y less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/flask-pika/app/processmon.toml
+++ b/python/flask-pika/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.flask]
 command = "flask"

--- a/python/flask-pika/app/processmon.worker.toml
+++ b/python/flask-pika/app/processmon.worker.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 # The worker service runs only the background worker. Work enqueued by the web
 # `app` service is performed here, so it reports under the worker's own app name

--- a/python/starlette/Dockerfile
+++ b/python/starlette/Dockerfile
@@ -5,6 +5,12 @@ ENV REFRESHED_AT=2023-05-23
 
 RUN apt-get update && apt-get install -y less
 
+# processmon watches /app and restarts on any file change. Python writes a
+# __pycache__ directory into every package it imports, and processmon can only
+# ignore __pycache__ directly under the watched path, not at deeper nesting.
+# Stop Python writing bytecode so those files never trigger a restart.
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Copy commands into the container
 RUN mkdir /commands
 COPY ./commands/* /commands/

--- a/python/starlette/app/processmon.toml
+++ b/python/starlette/app/processmon.toml
@@ -1,6 +1,5 @@
 [[paths_to_watch]]
 path = "/app"
-ignore = ["__pycache__"]
 
 [processes.starlette]
 command = "uvicorn"


### PR DESCRIPTION
This replaces #377, which tried to solve the same problem by ignoring `__pycache__` in the processmon configs.

processmon restarts the process whenever a watched file changes. Python writes a `__pycache__` directory of .pyc files into every package it imports, so those writes were triggering restarts.

The processmon configs tried to prevent this with `ignore = ["__pycache__"]`. That does not work at arbitrary depth. processmon joins the ignore entry onto the watched path and does a prefix match, so it only ignores `/app/__pycache__`. A `__pycache__` directory inside a nested package, such as `/app/some_package/__pycache__`, is never matched, so it still triggers a restart.

Set `PYTHONDONTWRITEBYTECODE=1` in each Python Dockerfile instead. Python then never writes .pyc files, so no `__pycache__` directory is created and there is nothing for processmon to react to. One environment variable also covers every process in the container, including the worker and downstream services, which the per-config ignore entries had to repeat.

Remove the now-redundant ignore entries from the processmon configs.

[skip changeset]